### PR TITLE
Update logo to smaller version, fix broken HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-<p align="center"><img src="https://github.com/cert-manager/cert-manager/blob/master/logo/logo.png" width="250x" /></p>
-</a>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png" height="256" width="256" alt="cert-manager project logo" />
+</p>
 <a href="https://godoc.org/github.com/cert-manager/csi-driver-spiffe"><img src="https://godoc.org/github.com/cert-manager/csi-driver-spiffe?status.svg"></a>
-<a href="https://goreportcard.com/report/github.com/cert-manager/csi-driver-spiffe"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/csi-driver-spiffe" /></a></p>
+<a href="https://goreportcard.com/report/github.com/cert-manager/csi-driver-spiffe"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/csi-driver-spiffe" /></a>
 
 # csi-driver-spiffe
 


### PR DESCRIPTION
Will stealth merge using a manual `lgtm` label