### PR TITLE
 Remove life cycle hook from Daemonset

### DIFF
--- a/deploy/charts/csi-driver-spiffe/Chart.yaml
+++ b/deploy/charts/csi-driver-spiffe/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/csi-driver-spiffe
 
 appVersion: v0.2.0
-version: v0.2.0
+version: v0.2.1

--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -1,6 +1,6 @@
 # cert-manager-csi-driver-spiffe
 
-![Version: v0.2.0](https://img.shields.io/badge/Version-v0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: v0.2.1](https://img.shields.io/badge/Version-v0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for cert-manager-csi-driver-spiffe
 

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -19,10 +19,6 @@ spec:
         - name: node-driver-registrar
           image: "{{ .Values.app.driver.nodeDriverRegistrarImage.repository }}:{{ .Values.app.driver.nodeDriverRegistrarImage.tag }}"
           imagePullPolicy: {{ .Values.app.driver.nodeDriverRegistrarImage.pullPolicy }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/cert-manager-csi-driver-spiffe /registration/cert-manager-csi-driver-spiffe-reg.sock"]
           args:
             - -v={{ .Values.app.logLevel }}
             - --csi-address=/plugin/csi.sock


### PR DESCRIPTION
See https://github.com/cert-manager/csi-driver/pull/110

Updates helm chart version to v0.2.1, ready for release.