### PR TITLE
Use `/usr/bin/env` instead of `/bin/bash` in hack scripts

### DIFF
--- a/hack/update-helm-docs.sh
+++ b/hack/update-helm-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2021 The cert-manager Authors.
 #

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2014 The Kubernetes Authors.
 #

--- a/hack/verify-helm-docs.sh
+++ b/hack/verify-helm-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2021 The cert-manager Authors.
 #


### PR DESCRIPTION
/assign @wallrj 