### PR TITLE
Add missing --csi-driver-name option to daemonset

### DIFF
--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -61,6 +61,8 @@ spec:
           args :
             - --log-level={{ .Values.app.logLevel }}
 
+            - --csi-driver-name={{ .Values.app.name }}
+
             - --certificate-request-duration={{ .Values.app.certificateRequestDuration }}
             - --issuer-name={{ .Values.app.issuer.name }}
             - --issuer-kind={{ .Values.app.issuer.kind }}


### PR DESCRIPTION
This was missing in the daemonset but present in the deployment with the confusing effect that the csidriver was listed when listing the csidrivers but reported as missing, when being useD