### PR TITLE
Change to use p256 instead of p521

### DIFF
--- a/internal/approver/evaluator/evaluator.go
+++ b/internal/approver/evaluator/evaluator.go
@@ -17,8 +17,6 @@ limitations under the License.
 package evaluator
 
 import (
-	"crypto/ecdsa"
-	"errors"
 	"fmt"
 	"time"
 
@@ -98,16 +96,12 @@ func (i *internal) Evaluate(req *cmapi.CertificateRequest) error {
 			csr.DNSNames, csr.IPAddresses, csr.Subject.CommonName, csr.EmailAddresses)
 	}
 
-	if ecdsapub, ok := csr.PublicKey.(*ecdsa.PublicKey); !ok || ecdsapub.Curve.Params().BitSize != 521 {
-		return errors.New("forbidden key used by requestor, expecting ECDSA P521")
-	}
-
 	if err := validateCSRExtentions(csr); err != nil {
 		return err
 	}
 
 	if req.Spec.IsCA {
-		return errors.New("request contains spec.isCA=true")
+		return fmt.Errorf("request contains spec.isCA=true")
 	}
 
 	if !util.EqualKeyUsagesUnsorted(req.Spec.Usages, requiedUsages) {

--- a/internal/approver/evaluator/evaluator_test.go
+++ b/internal/approver/evaluator/evaluator_test.go
@@ -176,60 +176,6 @@ func Test_Evaluate(t *testing.T) {
 			},
 			expErr: true,
 		},
-		"if request contains the wrong key type, expect error": {
-			req: func(t *testing.T) *cmapi.CertificateRequest {
-				csr, err := utilpki.GenerateCSR(&cmapi.Certificate{
-					Spec: cmapi.CertificateSpec{
-						PrivateKey: &cmapi.CertificatePrivateKey{Algorithm: cmapi.RSAKeyAlgorithm},
-						URIs:       []string{"spiffe://foo.bar/ns/sandbox/sa/sleep"},
-					},
-				})
-				assert.NoError(t, err)
-				pk, err := utilpki.GenerateRSAPrivateKey(2048)
-				assert.NoError(t, err)
-				csrDER, err := utilpki.EncodeCSR(csr, pk)
-				assert.NoError(t, err)
-				csrPEM := bytes.NewBuffer([]byte{})
-				assert.NoError(t, pem.Encode(csrPEM, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER}))
-				return &cmapi.CertificateRequest{Spec: cmapi.CertificateRequestSpec{
-					Request:  csrPEM.Bytes(),
-					Duration: &metav1.Duration{Duration: time.Hour},
-					Username: "system:serviceaccount:sandbox:sleep",
-					Usages: []cmapi.KeyUsage{
-						cmapi.UsageServerAuth, cmapi.UsageClientAuth,
-						cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment,
-					},
-				}}
-			},
-			expErr: true,
-		},
-		"if request contains the wrong key size, expect error": {
-			req: func(t *testing.T) *cmapi.CertificateRequest {
-				csr, err := utilpki.GenerateCSR(&cmapi.Certificate{
-					Spec: cmapi.CertificateSpec{
-						PrivateKey: &cmapi.CertificatePrivateKey{Algorithm: cmapi.ECDSAKeyAlgorithm},
-						URIs:       []string{"spiffe://foo.bar/ns/sandbox/sa/sleep"},
-					},
-				})
-				assert.NoError(t, err)
-				pk, err := utilpki.GenerateECPrivateKey(utilpki.ECCurve384)
-				assert.NoError(t, err)
-				csrDER, err := utilpki.EncodeCSR(csr, pk)
-				assert.NoError(t, err)
-				csrPEM := bytes.NewBuffer([]byte{})
-				assert.NoError(t, pem.Encode(csrPEM, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER}))
-				return &cmapi.CertificateRequest{Spec: cmapi.CertificateRequestSpec{
-					Request:  csrPEM.Bytes(),
-					Duration: &metav1.Duration{Duration: time.Hour},
-					Username: "system:serviceaccount:sandbox:sleep",
-					Usages: []cmapi.KeyUsage{
-						cmapi.UsageServerAuth, cmapi.UsageClientAuth,
-						cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment,
-					},
-				}}
-			},
-			expErr: true,
-		},
 		"if request is with isCA=true, expect error": {
 			req: func(t *testing.T) *cmapi.CertificateRequest {
 				csr, err := utilpki.GenerateCSR(&cmapi.Certificate{

--- a/internal/csi/driver/driver_test.go
+++ b/internal/csi/driver/driver_test.go
@@ -40,22 +40,25 @@ func Test_writeKeyPair(t *testing.T) {
 		cancel()
 	})
 
-	capk, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	capk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
+
 	caTmpl, err := utilpki.GenerateTemplate(&cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "my-ca"}})
 	require.NoError(t, err)
+
 	caPEM, ca, err := utilpki.SignCertificate(caTmpl, caTmpl, capk.Public(), capk)
 	require.NoError(t, err)
 
-	leafpk, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	leafpk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
+
 	leafTmpl, err := utilpki.GenerateTemplate(
 		&cmapi.Certificate{
 			Spec: cmapi.CertificateSpec{URIs: []string{"spiffe://cert-manager.io/ns/sandbox/sa/default"}},
 		},
 	)
-
 	require.NoError(t, err)
+
 	leafPEM, _, err := utilpki.SignCertificate(leafTmpl, ca, leafpk.Public(), capk)
 	require.NoError(t, err)
 
@@ -73,9 +76,12 @@ func Test_writeKeyPair(t *testing.T) {
 	}
 
 	meta := metadata.Metadata{VolumeID: "vol-id"}
+
 	_, err = store.RegisterMetadata(meta)
 	require.NoError(t, err)
-	require.NoError(t, d.writeKeypair(meta, leafpk, leafPEM, nil))
+
+	err = d.writeKeypair(meta, leafpk, leafPEM, nil)
+	require.NoError(t, err)
 
 	files, err := store.ReadFiles("vol-id")
 	require.NoError(t, err)


### PR DESCRIPTION
It seems the original choice to use P-521 [may have been a mistake](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1676473986055109), and in any case there's no real cryptographic justification for using it here over P-256 which will be faster and more widely supported.

Specifically, we've heard that envoy struggles with P-521 so switching will help with that use case.

This also removes the approver check for the curve. That check was incorrect (**checking the bit size of the underlying field doesn't confirm that the curve is P-521**) and was not in any case a worthwhile thing to confirm since we shouldn't really care what key is used.