### PR TITLE
Bump versions, fix old info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
 
 GOMARKDOC_FLAGS=--format github --repository.url "https://github.com/cert-manager/csi-driver-spiffe" --repository.default-branch master --repository.path /
 
+RELEASE_VERSION ?= 0.3.0
+
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
@@ -71,8 +73,8 @@ verify: test build ## Verify repo.
 # arguments to `--push`.
 .PHONY: image
 image: ## build docker image targeting all supported platforms
-	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe:v0.2.0 --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-oci -f Dockerfile.driver .
-	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:v0.2.0 --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-approver-oci -f Dockerfile.approver .
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe:v$(RELEASE_VERSION) --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-oci -f Dockerfile.driver .
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:v$(RELEASE_VERSION) --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-approver-oci -f Dockerfile.approver .
 
 .PHONY: demo
 demo: depend ## create cluster and deploy approver-policy

--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,19 @@ build-approver: ## Build approver binary.
 .PHONY: verify
 verify: test build ## Verify repo.
 
-# image will only build and store the image locally, targeted in OCI format.
-# To actually push an image to the public repo, replace the `--output` flag and
-# arguments to `--push`.
 .PHONY: image
 image: ## build docker image targeting all supported platforms
 	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe:v$(RELEASE_VERSION) --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-oci -f Dockerfile.driver .
 	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:v$(RELEASE_VERSION) --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-approver-oci -f Dockerfile.approver .
+
+# TODO: ideally we should ensure that image and image-push are identical save for the different output location (or we should use ko instead)
+# for now, we copy+paste the build steps to avoid the need for a manual edit to the Makefile in order to do a release
+# This allows us to release from a non-dirty checkout of a tag.
+
+.PHONY: image-push
+image-push: ## build docker images for all supported platforms and push to the remote registry
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe:v$(RELEASE_VERSION) --push -f Dockerfile.driver .
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:v$(RELEASE_VERSION) --push -f Dockerfile.approver .
 
 .PHONY: demo
 demo: depend ## create cluster and deploy approver-policy

--- a/deploy/charts/csi-driver-spiffe/Chart.yaml
+++ b/deploy/charts/csi-driver-spiffe/Chart.yaml
@@ -1,10 +1,8 @@
 apiVersion: v1
-
 name: cert-manager-csi-driver-spiffe
 type: application
-description: A Helm chart for cert-manager-csi-driver-spiffe
-
-home: https://github.com/cert-manager/csi-driver-spiffe
+description: cert-manager csi-driver-spiffe is a CSI plugin for Kubernetes which transparently delivers X.509 SPIFFE SVIDs to pods which mount it.
+home: https://cert-manager.io/docs/projects/csi-driver-spiffe/
 maintainers:
   - name: cert-manager-maintainers
     email: cert-manager-maintainers@googlegroups.com

--- a/deploy/charts/csi-driver-spiffe/Chart.yaml
+++ b/deploy/charts/csi-driver-spiffe/Chart.yaml
@@ -9,6 +9,5 @@ maintainers:
     url: https://cert-manager.io
 sources:
 - https://github.com/cert-manager/csi-driver-spiffe
-
-appVersion: v0.2.0
-version: v0.2.2
+appVersion: v0.3.0
+version: v0.3.0

--- a/deploy/charts/csi-driver-spiffe/Chart.yaml
+++ b/deploy/charts/csi-driver-spiffe/Chart.yaml
@@ -6,9 +6,9 @@ description: A Helm chart for cert-manager-csi-driver-spiffe
 
 home: https://github.com/cert-manager/csi-driver-spiffe
 maintainers:
-- name: joshvanl
-  email: joshua.vanleeuwen@jetstack.io
-  url: https://cert-manager.io
+  - name: cert-manager-maintainers
+    email: cert-manager-maintainers@googlegroups.com
+    url: https://cert-manager.io
 sources:
 - https://github.com/cert-manager/csi-driver-spiffe
 

--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -1,16 +1,16 @@
 # cert-manager-csi-driver-spiffe
 
-![Version: v0.2.2](https://img.shields.io/badge/Version-v0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: v0.3.0](https://img.shields.io/badge/Version-v0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
 
-A Helm chart for cert-manager-csi-driver-spiffe
+cert-manager csi-driver-spiffe is a CSI plugin for Kubernetes which transparently delivers X.509 SPIFFE SVIDs to pods which mount it.
 
-**Homepage:** <https://github.com/cert-manager/csi-driver-spiffe>
+**Homepage:** <https://cert-manager.io/docs/projects/csi-driver-spiffe/>
 
 ## Maintainers
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| joshvanl | <joshua.vanleeuwen@jetstack.io> | <https://cert-manager.io> |
+| cert-manager-maintainers | <cert-manager-maintainers@googlegroups.com> | <https://cert-manager.io> |
 
 ## Source Code
 
@@ -52,7 +52,7 @@ A Helm chart for cert-manager-csi-driver-spiffe
 | app.trustDomain | string | `"cluster.local"` | The Trust Domain for this driver. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on DaemonSet. |
 | image.repository | object | `{"approver":"quay.io/jetstack/cert-manager-csi-driver-spiffe-approver","driver":"quay.io/jetstack/cert-manager-csi-driver-spiffe"}` | Target image repository. |
-| image.tag | string | `"v0.2.0"` | Target image version tag. |
+| image.tag | string | `"v0.3.0"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the csi-driver-spiffe and csi-driver-spiffe-approver container images |
 | priorityClassName | string | `""` | Optional priority class to be used for the csi-driver pods. |
 

--- a/deploy/charts/csi-driver-spiffe/templates/NOTES.txt
+++ b/deploy/charts/csi-driver-spiffe/templates/NOTES.txt
@@ -1,0 +1,6 @@
+csi-driver-spiffe {{ .Chart.AppVersion }} has been deployed successfully!
+
+For usage instructions and a guide to getting started, check out the csi-driver-spiffe
+page on the cert-manager website:
+
+https://cert-manager.io/docs/projects/csi-driver-spiffe/

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -4,7 +4,7 @@ image:
     driver: quay.io/jetstack/cert-manager-csi-driver-spiffe
     approver: quay.io/jetstack/cert-manager-csi-driver-spiffe-approver
   # -- Target image version tag.
-  tag: v0.2.0
+  tag: v0.3.0
   # -- Kubernetes imagePullPolicy on DaemonSet.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This prepares for a release of 0.3.0, removes old info and improves the Helm chart.

This also adds a "image-push" target to help with releases. It's not ideal, but it works and doesn't leave us releasing from a dirty checkout.