### PR TITLE
Change release version to use a v, fixes generation of chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
 
 GOMARKDOC_FLAGS=--format github --repository.url "https://github.com/cert-manager/csi-driver-spiffe" --repository.default-branch master --repository.path /
 
-RELEASE_VERSION ?= 0.3.0
+RELEASE_VERSION ?= v0.3.0
 
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -70,8 +70,8 @@ verify: test build ## Verify repo.
 
 .PHONY: image
 image: ## build docker image targeting all supported platforms
-	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe:v$(RELEASE_VERSION) --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-oci -f Dockerfile.driver .
-	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:v$(RELEASE_VERSION) --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-approver-oci -f Dockerfile.approver .
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe:$(RELEASE_VERSION) --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-oci -f Dockerfile.driver .
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:$(RELEASE_VERSION) --output type=oci,dest=./bin/cert-manager-csi-driver-spiffe-approver-oci -f Dockerfile.approver .
 
 # TODO: ideally we should ensure that image and image-push are identical save for the different output location (or we should use ko instead)
 # for now, we copy+paste the build steps to avoid the need for a manual edit to the Makefile in order to do a release
@@ -79,8 +79,8 @@ image: ## build docker image targeting all supported platforms
 
 .PHONY: image-push
 image-push: ## build docker images for all supported platforms and push to the remote registry
-	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe:v$(RELEASE_VERSION) --push -f Dockerfile.driver .
-	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:v$(RELEASE_VERSION) --push -f Dockerfile.approver .
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe:$(RELEASE_VERSION) --push -f Dockerfile.driver .
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:$(RELEASE_VERSION) --push -f Dockerfile.approver .
 
 .PHONY: demo
 demo: depend ## create cluster and deploy approver-policy


### PR DESCRIPTION
As implemented, this will create a chart with version `0.3.0` instead of `v0.3.0` which will cause the Jetstack-internal charts repo to interpret the chart as invalid and in any case is a deviation from past charts where the versions were prefixed with `v`.

This change will apply to the release in v0.3.0 since it's minor and doesn't affect running code but is required for the release.

The release won't be retagged because it doesn't seem worth it.