### PR TITLE
Move csi-data-dir configuration into values.yaml

### DIFF
--- a/deploy/charts/csi-driver-spiffe/Chart.yaml
+++ b/deploy/charts/csi-driver-spiffe/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
     url: https://cert-manager.io
 sources:
 - https://github.com/cert-manager/csi-driver-spiffe
-appVersion: v0.3.0
-version: v0.3.0
+appVersion: v0.3.1
+version: v0.3.1

--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -1,6 +1,6 @@
 # cert-manager-csi-driver-spiffe
 
-![Version: v0.3.0](https://img.shields.io/badge/Version-v0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: v0.3.1](https://img.shields.io/badge/Version-v0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 cert-manager csi-driver-spiffe is a CSI plugin for Kubernetes which transparently delivers X.509 SPIFFE SVIDs to pods which mount it.
 
@@ -20,8 +20,6 @@ cert-manager csi-driver-spiffe is a CSI plugin for Kubernetes which transparentl
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| app.approver | object | `{"metrics":{"port":9402,"service":{"enabled":true,"servicemonitor":{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"},"type":"ClusterIP"}},"readinessProbe":{"port":6060},"replicaCount":1,"resources":{},"signerName":"clusterissuers.cert-manager.io/*"}` | Options for approver controller |
-| app.approver.metrics.port | int | `9402` | Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'. |
 | app.approver.metrics.service | object | `{"enabled":true,"servicemonitor":{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"},"type":"ClusterIP"}` | Service to expose metrics endpoint. |
 | app.approver.metrics.service.enabled | bool | `true` | Create a Service resource to expose metrics endpoint. |
 | app.approver.metrics.service.servicemonitor | object | `{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"}` | ServiceMonitor resource for this Service. |
@@ -30,7 +28,8 @@ cert-manager csi-driver-spiffe is a CSI plugin for Kubernetes which transparentl
 | app.approver.replicaCount | int | `1` | Number of replicas of the approver to run. |
 | app.approver.signerName | string | `"clusterissuers.cert-manager.io/*"` | The signer name that csi-driver-spiffe approver will be given permission to approve and deny. CertificateRequests referencing this signer name can be processed by the SPIFFE approver. See: https://cert-manager.io/docs/concepts/certificaterequest/#approval |
 | app.certificateRequestDuration | string | `"1h"` | Duration requested for requested certificates. |
-| app.driver | object | `{"livenessProbe":{"port":9809},"livenessProbeImage":{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/livenessprobe","tag":"v2.9.0"},"nodeDriverRegistrarImage":{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-node-driver-registrar","tag":"v2.7.0"},"resources":{},"sourceCABundle":null,"volumeFileName":{"ca":"ca.crt","cert":"tls.crt","key":"tls.key"},"volumeMounts":[],"volumes":[]}` | Options for CSI driver |
+| app.driver | object | `{"csiDataDir":"/tmp/cert-manager-csi-driver", "livenessProbe":{"port":9809},"livenessProbeImage":{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/livenessprobe","tag":"v2.9.0"},"nodeDriverRegistrarImage":{"pullPolicy":"IfNotPresent","repository":"registry.k8s.io/sig-storage/csi-node-driver-registrar","tag":"v2.7.0"},"resources":{},"sourceCABundle":null,"volumeFileName":{"ca":"ca.crt","cert":"tls.crt","key":"tls.key"},"volumeMounts":[],"volumes":[]}` | Options for CSI driver |
+| app.driver.csiDataDir | string | `"/tmp/cert-manager-csi-driver"` | Configures the hostPath directory that the driver will write and mount volumes from. |
 | app.driver.livenessProbe.port | int | `9809` | The port that will expose the liveness of the csi-driver |
 | app.driver.livenessProbeImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on liveness probe. |
 | app.driver.livenessProbeImage.repository | string | `"registry.k8s.io/sig-storage/livenessprobe"` | Target image repository. |
@@ -52,7 +51,7 @@ cert-manager csi-driver-spiffe is a CSI plugin for Kubernetes which transparentl
 | app.trustDomain | string | `"cluster.local"` | The Trust Domain for this driver. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on DaemonSet. |
 | image.repository | object | `{"approver":"quay.io/jetstack/cert-manager-csi-driver-spiffe-approver","driver":"quay.io/jetstack/cert-manager-csi-driver-spiffe"}` | Target image repository. |
-| image.tag | string | `"v0.3.0"` | Target image version tag. |
+| image.tag | string | `"v0.3.1"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the csi-driver-spiffe and csi-driver-spiffe-approver container images |
 | priorityClassName | string | `""` | Optional priority class to be used for the csi-driver pods. |
 

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -123,7 +123,7 @@ spec:
           type: Directory
         name: registration-dir
       - hostPath:
-          path: /tmp/cert-manager-csi-driver-spiffe
+          path: {{ .Values.app.driver.csiDataDir }}
           type: DirectoryOrCreate
         name: csi-data-dir
       {{- if .Values.app.driver.volumes }}

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -51,6 +51,9 @@ app:
     #- name: root-cas
     #  mountPath: /var/run/secrets/cert-manager-csi-driver-spiffe
 
+    # -- Configures the hostPath directory that the driver will write and mount volumes from.
+    csiDataDir: /tmp/cert-manager-csi-driver
+
     resources: {}
     # -- Kubernetes pod resource limits for cert-manager-csi-driver-spiffe
     # limits:


### PR DESCRIPTION
Equivalent to https://github.com/cert-manager/csi-driver/pull/73/files this allows a different hostPath to be used, working around an issue with system-tmpfiles-clean task.

We were running into this issue with EKS managed nodes which seem to cleanup /tmp every now and then.

Based on the last PR, please advise if I should bump the patch number of the helm chart