### PR TITLE
Helm chart improvements

### DIFF
--- a/deploy/charts/csi-driver-spiffe/templates/csidriver.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/csidriver.yaml
@@ -1,8 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1/CSIDriver" }}
 apiVersion: storage.k8s.io/v1
-{{- else }}
-apiVersion: storage.k8s.io/v1beta1
-{{- end }}
 kind: CSIDriver
 metadata:
   name: "{{ .Values.app.name }}"

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-csi-driver-spiffe.labels" . | indent 4 }}
 spec:

--- a/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-csi-driver-spiffe.labels" . | indent 4 }}
 spec:
@@ -37,9 +38,14 @@ spec:
           - --issuer-group={{ .Values.app.issuer.group }}
           - --trust-domain={{ .Values.app.trustDomain }}
 
-          - --leader-election-namespace={{ .Release.Namespace }}
+          - --leader-election-namespace=$(POD_NAMESPACE)
           - "--metrics-bind-address=:{{.Values.app.approver.metrics.port}}"
           - "--readiness-probe-bind-address=:{{.Values.app.approver.readinessProbe.port}}"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         resources:
 {{- toYaml .Values.app.approver.resources | nindent 12 }}
       {{- with .Values.priorityClassName }}

--- a/deploy/charts/csi-driver-spiffe/templates/metrics-service.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver
 {{ include "cert-manager-csi-driver-spiffe.labels" . | indent 4 }}

--- a/deploy/charts/csi-driver-spiffe/templates/role.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/role.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-csi-driver-spiffe.labels" . | indent 4 }}
 rules:

--- a/deploy/charts/csi-driver-spiffe/templates/rolebinding.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/rolebinding.yaml
@@ -2,6 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-csi-driver-spiffe.labels" . | indent 4 }}
 roleRef:

--- a/deploy/charts/csi-driver-spiffe/templates/serviceaccount.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ imagePullSecrets:
     {{- toYaml . | nindent 8 }}
 {{- end }}
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-csi-driver-spiffe.labels" . | indent 4 }}
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}
@@ -16,6 +17,7 @@ imagePullSecrets:
     {{- toYaml . | nindent 8 }}
 {{- end }}
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-csi-driver-spiffe.labels" . | indent 4 }}
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver


### PR DESCRIPTION
- remove deprecated `storage.k8s.io/v1beta1`
- add namespace values that make sure namespace is included when running `helm template`
- use dynamic `$(POD_NAMESPACE)` instead of static templated `{{ .Release.Namespace }}` value (should resolve to same value)