### PR TITLE
Added tolerations,nodeSelector,affinity,topologySpreadConstraints

### DIFF
--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -429,19 +429,10 @@ Labels to apply to all resources
 #### **nodeSelector** ~ `object`
 > Default value:
 > ```yaml
-> {}
+> kubernetes.io/os: linux
 > ```
 
-Kubernetes node selector: node labels for pod assignment.  
-  
-Recommended value:
-
-```yaml
-nodeSelector:
-  kubernetes.io/os: linux
-```
-
-
+Kubernetes node selector: node labels for pod assignment.
 
 #### **affinity** ~ `object`
 > Default value:

--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -426,5 +426,71 @@ Optional priority class to be used for the csi-driver pods.
 > ```
 
 Labels to apply to all resources
+#### **nodeSelector** ~ `object`
+> Default value:
+> ```yaml
+> kubernetes.io/os: linux
+> ```
+
+Kubernetes node selector: node labels for pod assignment.
+
+#### **affinity** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Kubernetes affinity: constraints for pod assignment.  
+  
+For example:
+
+```yaml
+affinity:
+  nodeAffinity:
+   requiredDuringSchedulingIgnoredDuringExecution:
+     nodeSelectorTerms:
+     - matchExpressions:
+       - key: foo.bar.com/role
+         operator: In
+         values:
+         - master
+```
+#### **tolerations** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Kubernetes pod tolerations for cert-manager-csi-driver-spiffe.  
+  
+For example:
+
+```yaml
+tolerations:
+- key: foo.bar.com/role
+  operator: Equal
+  value: master
+  effect: NoSchedule
+```
+#### **topologySpreadConstraints** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+List of Kubernetes TopologySpreadConstraints.  
+  
+For example:
+
+```yaml
+topologySpreadConstraints:
+- maxSkew: 2
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: controller
+```
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -429,10 +429,19 @@ Labels to apply to all resources
 #### **nodeSelector** ~ `object`
 > Default value:
 > ```yaml
-> kubernetes.io/os: linux
+> {}
 > ```
 
-Kubernetes node selector: node labels for pod assignment.
+Kubernetes node selector: node labels for pod assignment.  
+  
+Recommended value:
+
+```yaml
+nodeSelector:
+  kubernetes.io/os: linux
+```
+
+
 
 #### **affinity** ~ `object`
 > Default value:

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -119,6 +119,18 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
       volumes:
       - name: plugin-dir

--- a/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
@@ -49,3 +49,19 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with  .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -3,6 +3,9 @@
     "helm-values": {
       "additionalProperties": false,
       "properties": {
+        "affinity": {
+          "$ref": "#/$defs/helm-values.affinity"
+        },
         "app": {
           "$ref": "#/$defs/helm-values.app"
         },
@@ -18,10 +21,24 @@
         "imagePullSecrets": {
           "$ref": "#/$defs/helm-values.imagePullSecrets"
         },
+        "nodeSelector": {
+          "$ref": "#/$defs/helm-values.nodeSelector"
+        },
         "priorityClassName": {
           "$ref": "#/$defs/helm-values.priorityClassName"
+        },
+        "tolerations": {
+          "$ref": "#/$defs/helm-values.tolerations"
+        },
+        "topologySpreadConstraints": {
+          "$ref": "#/$defs/helm-values.topologySpreadConstraints"
         }
       },
+      "type": "object"
+    },
+    "helm-values.affinity": {
+      "default": {},
+      "description": "Kubernetes affinity: constraints for pod assignment.\n\nFor example:\naffinity:\n  nodeAffinity:\n   requiredDuringSchedulingIgnoredDuringExecution:\n     nodeSelectorTerms:\n     - matchExpressions:\n       - key: foo.bar.com/role\n         operator: In\n         values:\n         - master",
       "type": "object"
     },
     "helm-values.app": {
@@ -526,10 +543,29 @@
       "items": {},
       "type": "array"
     },
+    "helm-values.nodeSelector": {
+      "default": {
+        "kubernetes.io/os": "linux"
+      },
+      "description": "Kubernetes node selector: node labels for pod assignment.",
+      "type": "object"
+    },
     "helm-values.priorityClassName": {
       "default": "",
       "description": "Optional priority class to be used for the csi-driver pods.",
       "type": "string"
+    },
+    "helm-values.tolerations": {
+      "default": [],
+      "description": "Kubernetes pod tolerations for cert-manager-csi-driver-spiffe.\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.topologySpreadConstraints": {
+      "default": [],
+      "description": "List of Kubernetes TopologySpreadConstraints.\n\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/instance: cert-manager\n      app.kubernetes.io/component: controller",
+      "items": {},
+      "type": "array"
     }
   },
   "$ref": "#/$defs/helm-values",

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -221,9 +221,13 @@ priorityClassName: ""
 commonLabels: {}
 
 # Kubernetes node selector: node labels for pod assignment.
+#
+# Recommended value:
+#   nodeSelector:
+#     kubernetes.io/os: linux
+#
 # +docs:property=nodeSelector
-nodeSelector:
-  kubernetes.io/os: linux
+nodeSelector: {}
 
 # Kubernetes affinity: constraints for pod assignment.
 #

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -221,13 +221,9 @@ priorityClassName: ""
 commonLabels: {}
 
 # Kubernetes node selector: node labels for pod assignment.
-#
-# Recommended value:
-#   nodeSelector:
-#     kubernetes.io/os: linux
-#
 # +docs:property=nodeSelector
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/os: linux
 
 # Kubernetes affinity: constraints for pod assignment.
 #

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -19,13 +19,14 @@ image:
   # +docs:property
   # tag: vX.Y.Z
 
-  digest: {}
+  digest:
+    {}
     # Target csi-driver driver digest. Override any tag, if set.
     # For example:
     #   driver: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
     # +docs:property=image.digest.driver
     # driver: sha256:...
-    
+
     # Target csi-driver approver digest. Override any tag, if set.
     # For example:
     #   approver: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
@@ -192,7 +193,7 @@ app:
           # Create Prometheus ServiceMonitor resource for cert-manager-csi-driver-spiffe approver.
           enabled: false
           # The value for the "prometheus" label on the ServiceMonitor. This allows
-          # for multiple Prometheus instances selecting difference ServiceMonitors 
+          # for multiple Prometheus instances selecting difference ServiceMonitors
           # using label selectors.
           prometheusInstance: default
           # The interval that the Prometheus will scrape for metrics.
@@ -218,3 +219,45 @@ priorityClassName: ""
 
 # Labels to apply to all resources
 commonLabels: {}
+
+# Kubernetes node selector: node labels for pod assignment.
+# +docs:property=nodeSelector
+nodeSelector:
+  kubernetes.io/os: linux
+
+# Kubernetes affinity: constraints for pod assignment.
+#
+# For example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+
+# Kubernetes pod tolerations for cert-manager-csi-driver-spiffe.
+#
+# For example:
+#   tolerations:
+#   - key: foo.bar.com/role
+#     operator: Equal
+#     value: master
+#     effect: NoSchedule
+tolerations: []
+
+# List of Kubernetes TopologySpreadConstraints.
+#
+# For example:
+#   topologySpreadConstraints:
+#   - maxSkew: 2
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/instance: cert-manager
+#         app.kubernetes.io/component: controller
+topologySpreadConstraints: []


### PR DESCRIPTION
When i tried to deploy a helm chart to tainted nodes i figured out that templates didn't contain the Kubernetes scheduler fields like:

* tolerations
* nodeSelector
* affinity
* topologySpreadConstraints

Added it to deployment and daemonset.