### PR TITLE
Add version info to binary at compile time

### DIFF
--- a/internal/csi/app/app.go
+++ b/internal/csi/app/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/app/options"
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/driver"
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/rootca"
+	"github.com/cert-manager/csi-driver-spiffe/internal/version"
 )
 
 const (
@@ -46,6 +47,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := opts.Logr.WithName("main")
+			log.Info("Version", "info", version.VersionInfo())
 
 			var rootCA rootca.Interface
 			if len(opts.Volume.SourceCABundleFile) > 0 {

--- a/internal/csi/app/app.go
+++ b/internal/csi/app/app.go
@@ -47,7 +47,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := opts.Logr.WithName("main")
-			log.Info("Version", "info", version.VersionInfo())
+			log.Info("Starting driver", "version", version.VersionInfo())
 
 			var rootCA rootca.Interface
 			if len(opts.Volume.SourceCABundleFile) > 0 {

--- a/internal/csi/driver/camanager.go
+++ b/internal/csi/driver/camanager.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/rootca"
+	"github.com/cert-manager/csi-driver-spiffe/internal/version"
 	"github.com/cert-manager/csi-lib/storage"
 	"github.com/go-logr/logr"
 )
@@ -131,6 +132,7 @@ func (c *camanager) updateRootCAFiles() error {
 	}
 
 	log := c.log.WithName("ca-updater")
+	log.Info("Version", "info", version.VersionInfo())
 
 	volumeIDs, err := c.store.ListVolumes()
 	if err != nil {

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/rootca"
+	"github.com/cert-manager/csi-driver-spiffe/internal/version"
 )
 
 // Options holds the Options needed for the CSI driver.
@@ -185,7 +186,7 @@ func New(log logr.Logger, opts Options) (*Driver, error) {
 	mngrLog := d.log.WithName("manager")
 	d.driver, err = driver.New(opts.Endpoint, d.log.WithName("driver"), driver.Options{
 		DriverName:    opts.DriverName,
-		DriverVersion: "v0.2.0",
+		DriverVersion: version.AppVersion,
 		NodeID:        opts.NodeID,
 		Store:         d.store,
 		Manager: manager.NewManagerOrDie(manager.Options{

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func init() {
+	if AppVersion == "" || GitCommit == "" {
+		fmt.Fprintf(os.Stderr, "warning: AppVersion or GitCommit not set, this binary was built without -ldflags \"-X internal/version.AppVersion=... -X internal/version.GitCommit=...\"\n")
+	}
+}
+
+type Version struct {
+	AppVersion string `json:"appVersion"`
+	GitCommit  string `json:"gitCommit"`
+	GoVersion  string `json:"goVersion"`
+	Compiler   string `json:"compiler"`
+	Platform   string `json:"platform"`
+}
+
+// This variable block holds information used to build up the version string
+var (
+	AppVersion = ""
+	GitCommit  = ""
+)
+
+func VersionInfo() Version {
+	return Version{
+		AppVersion: AppVersion,
+		GitCommit:  GitCommit,
+		GoVersion:  runtime.Version(),
+		Compiler:   runtime.Compiler,
+		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
Prints the version info on startup and passes the version string to csi-lib.