### PR TITLE
use exit code from recommended range

### DIFF
--- a/internal/approver/controller/controller.go
+++ b/internal/approver/controller/controller.go
@@ -95,7 +95,7 @@ func AddApprover(ctx context.Context, log logr.Logger, opts Options) error {
 			// CertificateRequests on start.
 			if err != nil {
 				a.log.Error(err, "failed to list all CertificateRequests, exiting error")
-				os.Exit(-1)
+				os.Exit(1)
 			}
 
 			// Ignore requests that already have an Approved or Denied condition.


### PR DESCRIPTION
```console
$ go doc os Exit
package os // import os

func Exit(code int)
    Exit causes the current program to exit with the given status code.
    Conventionally, code zero indicates success, non-zero an error. The program
    terminates immediately; deferred functions are not run.

    For portability, the status code should be in the range [0, 125].
```