### PR TITLE
Two minor tweaks

### DIFF
--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: {{ include "cert-manager-csi-driver-spiffe.name" . }}
         {{- include "cert-manager-csi-driver-spiffe.labels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: cert-manager-csi-driver-spiffe
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/internal/approver/evaluator/evaluator.go
+++ b/internal/approver/evaluator/evaluator.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	requiedUsages = []cmapi.KeyUsage{
+	requiredUsages = []cmapi.KeyUsage{
 		cmapi.UsageKeyEncipherment,
 		cmapi.UsageDigitalSignature,
 		cmapi.UsageClientAuth,
@@ -104,8 +104,8 @@ func (i *internal) Evaluate(req *cmapi.CertificateRequest) error {
 		return fmt.Errorf("request contains spec.isCA=true")
 	}
 
-	if !util.EqualKeyUsagesUnsorted(req.Spec.Usages, requiedUsages) {
-		return fmt.Errorf("request contains wrong usages, exp=%v got=%v", requiedUsages, req.Spec.Usages)
+	if !util.EqualKeyUsagesUnsorted(req.Spec.Usages, requiredUsages) {
+		return fmt.Errorf("request contains wrong usages, exp=%v got=%v", requiredUsages, req.Spec.Usages)
 	}
 
 	if err := i.validateIdentity(csr, req.Spec.Username); err != nil {


### PR DESCRIPTION
1. Fixes a typo in a variable name
2. Adds the default container annotation which makes it easier to query logs for the csi-driver pod (similar to https://github.com/cert-manager/csi-driver/pull/223)