### PR TITLE
Rename DaemonSet for easier tab completion

### DIFF
--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "cert-manager-csi-driver-spiffe.name" . }}
+  name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-driver
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cert-manager-csi-driver-spiffe.labels" . | nindent 4 }}


### PR DESCRIPTION
Currently, if I want to view logs for a pod in the csi-driver-spiffe DaemonSet I type:

```console
kubectl logs -n cert-manager cert-manager-csi<TAB>
```

which will be automatically expanded to:

```console
kubectl logs -n cert-manager cert-manager-csi-driver-spiffe-
```

On a local single node cluster, I then have two options:

```console
kubectl logs -n cert-manager cert-manager-csi-driver-spiffe-<TAB>
cert-manager-csi-driver-spiffe-approver-66b4645b58-d8hrl  cert-manager-csi-driver-spiffe-ng927
```

If I want to view logs for the approver, I can type `a<TAB>` to get the approver logs, because there's a predictable suffix.

If I want to view the logs for the driver, I need to look up at the screen and look at what random character was used for the pod's name. In the example above, `n` but obviously it changes.

By renaming the DaemonSet to `cert-manager-csi-driver-spiffe-driver` we can autocomplete faster. Type `a<TAB>` for the approver, and type `d<TAB>` for the driver.

I wasn't able to come up with a reason not to make this change; obviously, if this were to cause a breakage it wouldn't be worth it just for better autocompletion. But this seems safe and the improvement is surprisingly big for developer UX.