### PR TITLE
Remove issuerRef from approver

### DIFF
--- a/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
@@ -34,9 +34,6 @@ spec:
           - --csi-driver-name={{ .Values.app.name }}
 
           - --certificate-request-duration={{ .Values.app.certificateRequestDuration }}
-          - --issuer-name={{ .Values.app.issuer.name }}
-          - --issuer-kind={{ .Values.app.issuer.kind }}
-          - --issuer-group={{ .Values.app.issuer.group }}
           - --trust-domain={{ .Values.app.trustDomain }}
 
           - --leader-election-namespace=$(POD_NAMESPACE)

--- a/internal/approver/app/app.go
+++ b/internal/approver/app/app.go
@@ -86,7 +86,6 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			})
 
 			if err := controller.AddApprover(ctx, opts.Logr, controller.Options{
-				IssuerRef: opts.CertManager.IssuerRef,
 				Evaluator: evaluator,
 				Manager:   mgr,
 			}); err != nil {

--- a/internal/approver/app/options/options.go
+++ b/internal/approver/app/options/options.go
@@ -19,7 +19,6 @@ package options
 import (
 	"time"
 
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/spf13/pflag"
 
 	"github.com/cert-manager/csi-driver-spiffe/internal/flags"
@@ -57,17 +56,12 @@ type OptionsController struct {
 
 // OptionsCertManager are options specific to cert-manager and the evaluator.
 type OptionsCertManager struct {
-	// TrustDomain is the Trust Domain the evaluator will enforce requests request
-	// for.
+	// TrustDomain is the Trust Domain the evaluator will enforce requests request for.
 	TrustDomain string
 
 	// CertificateRequestDuration is the duration the evaluator will enforce
 	// CertificateRequest request for.
 	CertificateRequestDuration time.Duration
-
-	// IssuerRef is the issuer reference that will be used to match on created
-	// CertificateRequests.
-	IssuerRef cmmeta.ObjectReference
 }
 
 func New() *Options {
@@ -85,12 +79,27 @@ func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.CertManager.CertificateRequestDuration, "certificate-request-duration", time.Hour,
 		"The duration which is enforced for requests to have.")
 
-	fs.StringVar(&o.CertManager.IssuerRef.Name, "issuer-name", "my-spiffe-ca",
-		"Name of issuer which is matched against to evaluate on.")
-	fs.StringVar(&o.CertManager.IssuerRef.Kind, "issuer-kind", "ClusterIssuer",
-		"Kind of issuer which is matched against to evaluate on.")
-	fs.StringVar(&o.CertManager.IssuerRef.Group, "issuer-group", "cert-manager.io",
-		"Group of issuer which is matched against to evaluate on.")
+	// allow issuer-* args to still be passed to avoid a backwards incompatible change
+	var dummyIssuerRefName, dummyIssuerRefKind, dummyIssuerRefGroup string
+
+	fs.StringVar(&dummyIssuerRefName, "issuer-name", "", "Deprecated; value is ignored")
+	fs.StringVar(&dummyIssuerRefKind, "issuer-kind", "", "Deprecated; value is ignored")
+	fs.StringVar(&dummyIssuerRefGroup, "issuer-group", "", "Deprecated; value is ignored")
+
+	err := fs.MarkDeprecated("issuer-name", "issuer-name is deprecated and will be ignored")
+	if err != nil {
+		panic("failed to mark issuer-name flag as deprecated; this is an internal programming error")
+	}
+
+	err = fs.MarkDeprecated("issuer-kind", "issuer-kind is deprecated and will be ignored")
+	if err != nil {
+		panic("failed to mark issuer-kind flag as deprecated; this is an internal programming error")
+	}
+
+	err = fs.MarkDeprecated("issuer-group", "issuer-group is deprecated and will be ignored")
+	if err != nil {
+		panic("failed to mark issuer-group flag as deprecated; this is an internal programming error")
+	}
 }
 
 func (o *Options) addControllerFlags(fs *pflag.FlagSet) {

--- a/test/e2e/suite/approval/approval.go
+++ b/test/e2e/suite/approval/approval.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/cert-manager/csi-driver-spiffe/internal/annotations"
 	"github.com/cert-manager/csi-driver-spiffe/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -107,13 +108,17 @@ var _ = framework.CasesDescribe("Approval", func() {
 
 	It("should approve a valid request", func() {
 		By("Creating valid request")
+		spiffeID := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, serviceAccount.Name)
 		certificateRequest := cmapi.CertificateRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-request-",
 				Namespace:    f.Namespace.Name,
+				Annotations: map[string]string{
+					annotations.SPIFFEIdentityAnnnotationKey: spiffeID,
+				},
 			},
 			Spec: cmapi.CertificateRequestSpec{
-				Request:   genCSRPEM(pk, cmapi.ECDSAKeyAlgorithm, fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, serviceAccount.Name)),
+				Request:   genCSRPEM(pk, cmapi.ECDSAKeyAlgorithm, spiffeID),
 				Duration:  &metav1.Duration{Duration: time.Hour},
 				IssuerRef: f.Config().IssuerRef,
 				IsCA:      false,
@@ -131,13 +136,18 @@ var _ = framework.CasesDescribe("Approval", func() {
 
 	It("should deny a request with the wrong duration", func() {
 		By("Creating request with wrong duration")
+
+		spiffeID := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, serviceAccount.Name)
 		certificateRequest := cmapi.CertificateRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-request-",
 				Namespace:    f.Namespace.Name,
+				Annotations: map[string]string{
+					annotations.SPIFFEIdentityAnnnotationKey: spiffeID,
+				},
 			},
 			Spec: cmapi.CertificateRequestSpec{
-				Request:   genCSRPEM(pk, cmapi.ECDSAKeyAlgorithm, fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, serviceAccount.Name)),
+				Request:   genCSRPEM(pk, cmapi.ECDSAKeyAlgorithm, spiffeID),
 				Duration:  &metav1.Duration{Duration: time.Hour * 3},
 				IssuerRef: f.Config().IssuerRef,
 				IsCA:      false,
@@ -155,13 +165,19 @@ var _ = framework.CasesDescribe("Approval", func() {
 
 	It("should deny a request with the wrong SPIFFE ID", func() {
 		By("Creating request with wrong SPIFFE ID")
+
+		wrongSPIFFEID := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, "not-the-right-sa")
+
 		certificateRequest := cmapi.CertificateRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-request-",
 				Namespace:    f.Namespace.Name,
+				Annotations: map[string]string{
+					annotations.SPIFFEIdentityAnnnotationKey: wrongSPIFFEID,
+				},
 			},
 			Spec: cmapi.CertificateRequestSpec{
-				Request:   genCSRPEM(pk, cmapi.ECDSAKeyAlgorithm, fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, "not-the-right-sa")),
+				Request:   genCSRPEM(pk, cmapi.ECDSAKeyAlgorithm, wrongSPIFFEID),
 				Duration:  &metav1.Duration{Duration: time.Hour},
 				IssuerRef: f.Config().IssuerRef,
 				IsCA:      false,
@@ -179,13 +195,19 @@ var _ = framework.CasesDescribe("Approval", func() {
 
 	It("should deny a request with the wrong key usages", func() {
 		By("Creating request with wrong key usages")
+
+		spiffeID := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, serviceAccount.Name)
+
 		certificateRequest := cmapi.CertificateRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-request-",
 				Namespace:    f.Namespace.Name,
+				Annotations: map[string]string{
+					annotations.SPIFFEIdentityAnnnotationKey: spiffeID,
+				},
 			},
 			Spec: cmapi.CertificateRequestSpec{
-				Request:   genCSRPEM(pk, cmapi.ECDSAKeyAlgorithm, fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, serviceAccount.Name)),
+				Request:   genCSRPEM(pk, cmapi.ECDSAKeyAlgorithm, spiffeID),
 				Duration:  &metav1.Duration{Duration: time.Hour},
 				IssuerRef: f.Config().IssuerRef,
 				IsCA:      false,
@@ -206,13 +228,19 @@ var _ = framework.CasesDescribe("Approval", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating request with wrong key type")
+
+		spiffeID := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, serviceAccount.Name)
+
 		certificateRequest := cmapi.CertificateRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-request-",
 				Namespace:    f.Namespace.Name,
+				Annotations: map[string]string{
+					annotations.SPIFFEIdentityAnnnotationKey: spiffeID,
+				},
 			},
 			Spec: cmapi.CertificateRequestSpec{
-				Request:   genCSRPEM(pk, cmapi.RSAKeyAlgorithm, fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", f.Namespace.Name, serviceAccount.Name)),
+				Request:   genCSRPEM(pk, cmapi.RSAKeyAlgorithm, spiffeID),
 				Duration:  &metav1.Duration{Duration: time.Hour},
 				IssuerRef: f.Config().IssuerRef,
 				IsCA:      false,


### PR DESCRIPTION
The approver currently filters CertificateRequest resources based on the issuerRef they have configured, which will be incredibly complicated to handle in a scenario where we allow runtime configuration of issuers.

It also doesn't really provide any guarantees, guardrails or value, but does introduce a race condition when the issuer is updated. Updating the issuer cannot be synchronized everywhere at the same time, so there's always a period after an issuer update in which the driver could be using the new issuer and the approver could be looking for the old issuer.

This commit removes the issuerRef for the approver while keeping backwards compatibility with existing uses of the `--issuer-*` flags.

It replaces filtering of CertificateRequests by issuerRef with filtering based on the presence of the standard annotation which contains the SPIFFE ID. This helps to ensure that irrelevant CR resources are not considered.