### PR TITLE
Increase timeouts for camanager test

### DIFF
--- a/internal/csi/driver/camanager_test.go
+++ b/internal/csi/driver/camanager_test.go
@@ -58,7 +58,7 @@ func Test_manageCAFiles(t *testing.T) {
 	select {
 	case <-calledCtx.Done():
 		break
-	case <-time.After(time.Millisecond * 500):
+	case <-time.After(time.Second * 5):
 		assert.Fail(t, "updateRootCAFilesFn() was not called in time")
 	}
 
@@ -82,7 +82,7 @@ func Test_manageCAFiles(t *testing.T) {
 	select {
 	case <-calledTwiceChan:
 		break
-	case <-time.After(time.Millisecond * 500):
+	case <-time.After(time.Second * 5):
 		assert.Fail(t, "updateRootCAFilesFn() was not called twice in time")
 	}
 }


### PR DESCRIPTION
These timeouts are incredibly aggressive and caused test flakes on my machine when testing unrelated changes.

NB: I'm not 100% confident that these tests are really useful, but rather than ripping them out it seems easier to bump the timeouts