### PR TITLE
Move parsing of custom annotations to testable function

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package annotations holds constants which represent built-in csi-driver-spiffe annotations
+package annotations
+
+const (
+	Prefix = "spiffe.csi.cert-manager.io"
+
+	SPIFFEIdentityAnnnotationKey = "spiffe.csi.cert-manager.io/identity"
+)

--- a/internal/csi/app/app.go
+++ b/internal/csi/app/app.go
@@ -19,7 +19,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -62,15 +61,6 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				log.Info("propagating root CA bundle disabled")
 			}
 
-			annotations := map[string]string{}
-			for key, value := range opts.CertManager.CertificateRequestAnnotations {
-				if strings.HasPrefix(key, "spiffe.csi.cert-manager.io") {
-					log.Error(nil, "custom annotations must not begin with spiffe.csi.cert-manager.io", "annotation-key", key)
-				} else {
-					annotations[key] = value
-				}
-			}
-
 			driver, err := driver.New(opts.Logr, driver.Options{
 				DriverName: opts.DriverName,
 				NodeID:     opts.Driver.NodeID,
@@ -79,7 +69,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 				RestConfig:                    opts.RestConfig,
 				TrustDomain:                   opts.CertManager.TrustDomain,
-				CertificateRequestAnnotations: annotations,
+				CertificateRequestAnnotations: opts.CertManager.CertificateRequestAnnotations,
 				CertificateRequestDuration:    opts.CertManager.CertificateRequestDuration,
 				IssuerRef:                     opts.CertManager.IssuerRef,
 

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -160,25 +160,27 @@ func New(log logr.Logger, opts Options) (*Driver, error) {
 		certificateRequestAnnotations: sanitizedAnnotations,
 	}
 
-	// Set sane defaults.
 	if len(d.certFileName) == 0 {
 		d.certFileName = "tls.crt"
 	}
+
 	if len(d.keyFileName) == 0 {
 		d.keyFileName = "tls.key"
 	}
+
 	if len(d.caFileName) == 0 {
 		d.caFileName = "ca.crt"
 	}
+
 	if d.certificateRequestDuration == 0 {
 		d.certificateRequestDuration = time.Hour
 	}
 
-	var err error
 	store, err := storage.NewFilesystem(d.log, opts.DataRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup filesystem: %w", err)
 	}
+
 	// Used by clients to set the stored file's file-system group before
 	// mounting.
 	store.FSGroupVolumeAttributeKey = "spiffe.csi.cert-manager.io/fs-group"


### PR DESCRIPTION
This makes it simpler for us to test that annotations are correctly sanitized and ensures that all drivers - wherever they're created - will have sanitized annotations in the future.

Also makes some minor whitespace / comment adjustments and removes an unused `var err error`