### PR TITLE
Add env var for focusing on individual e2e tests

### DIFF
--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -74,12 +74,15 @@ test-e2e-deps: INSTALL_OPTIONS += --set app.driver.volumeMounts[0].mountPath=/va
 test-e2e-deps: INSTALL_OPTIONS += --set app.driver.sourceCABundle=/var/run/secrets/cert-manager-csi-driver-spiffe/ca.crt
 test-e2e-deps: install
 
+E2E_FOCUS ?=
+
 .PHONY: test-e2e
 ## e2e end-to-end tests
 ## @category Testing
 test-e2e: test-e2e-deps | kind-cluster $(NEEDS_GINKGO) $(NEEDS_KUBECTL) $(ARTIFACTS)
 	$(GINKGO) \
 		--output-dir=$(ARTIFACTS) \
+		--focus="$(E2E_FOCUS)" \
 		--junit-report=junit-go-e2e.xml \
 		./test/e2e/ \
 		-ldflags $(go_manager_ldflags) \


### PR DESCRIPTION
Simple change to help with development; tested locally that this has no effect unless a test name is given