### PR TITLE
Allow runtime configuration of issuers

### DIFF
--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -94,6 +94,15 @@ Verbosity of cert-manager-csi-driver logging.
 > ```
 
 Duration requested for requested certificates.
+#### **app.runtimeIssuanceConfigMap** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Name of a ConfigMap in the installation namespace to watch, providing runtime configuration of an issuer to use.  
+  
+The "issuer-name", "issuer-kind" and "issuer-group" keys must be present in the ConfigMap for it to be used.
 #### **app.extraCertificateRequestAnnotations** ~ `unknown`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -83,6 +83,8 @@ spec:
             - --node-id=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --data-root=csi-data-dir
+            - "--runtime-issuance-config-map-name={{.Values.app.runtimeIssuanceConfigMap}}"
+            - "--runtime-issuance-config-map-namespace={{.Release.Namespace}}"
           {{- if .Values.app.extraCertificateRequestAnnotations }}
             - --extra-certificate-request-annotations={{ .Values.app.extraCertificateRequestAnnotations }}
           {{- end }}

--- a/deploy/charts/csi-driver-spiffe/templates/role.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/role.yaml
@@ -1,6 +1,24 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: {{ include "cert-manager-csi-driver-spiffe.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cert-manager-csi-driver-spiffe.labels" . | nindent 4 }}
+rules:
+{{- if .Values.app.runtimeIssuanceConfigMap }}
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+  resourceNames: ["{{.Values.app.runtimeIssuanceConfigMap}}"]
+{{- end }}
+
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver
   namespace: {{ .Release.Namespace }}
   labels:

--- a/deploy/charts/csi-driver-spiffe/templates/rolebinding.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/rolebinding.yaml
@@ -1,6 +1,24 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: {{ include "cert-manager-csi-driver-spiffe.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cert-manager-csi-driver-spiffe.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cert-manager-csi-driver-spiffe.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cert-manager-csi-driver-spiffe.name" . }}
+  namespace: {{ .Release.Namespace }}
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver
   namespace: {{ .Release.Namespace }}
   labels:

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -65,6 +65,9 @@
         "name": {
           "$ref": "#/$defs/helm-values.app.name"
         },
+        "runtimeIssuanceConfigMap": {
+          "$ref": "#/$defs/helm-values.app.runtimeIssuanceConfigMap"
+        },
         "trustDomain": {
           "$ref": "#/$defs/helm-values.app.trustDomain"
         }
@@ -445,6 +448,11 @@
     "helm-values.app.name": {
       "default": "spiffe.csi.cert-manager.io",
       "description": "The name for the CSI driver installation.",
+      "type": "string"
+    },
+    "helm-values.app.runtimeIssuanceConfigMap": {
+      "default": "",
+      "description": "Name of a ConfigMap in the installation namespace to watch, providing runtime configuration of an issuer to use.\n\nThe \"issuer-name\", \"issuer-kind\" and \"issuer-group\" keys must be present in the ConfigMap for it to be used.",
       "type": "string"
     },
     "helm-values.app.trustDomain": {

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -48,6 +48,14 @@ app:
   logLevel: 1 # 1-5
   # Duration requested for requested certificates.
   certificateRequestDuration: 1h
+
+  # Name of a ConfigMap in the installation namespace to watch, providing
+  # runtime configuration of an issuer to use.
+  #
+  # The "issuer-name", "issuer-kind" and "issuer-group" keys must be present in
+  # the ConfigMap for it to be used.
+  runtimeIssuanceConfigMap: ""
+
   # List of annotations to add to certificate requests
   #
   # For example:

--- a/internal/csi/app/app.go
+++ b/internal/csi/app/app.go
@@ -71,7 +71,10 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				TrustDomain:                   opts.CertManager.TrustDomain,
 				CertificateRequestAnnotations: opts.CertManager.CertificateRequestAnnotations,
 				CertificateRequestDuration:    opts.CertManager.CertificateRequestDuration,
-				IssuerRef:                     opts.CertManager.IssuerRef,
+				IssuerRef:                     &opts.CertManager.IssuerRef,
+
+				IssuanceConfigMapName:      opts.CertManager.IssuanceConfigMapName,
+				IssuanceConfigMapNamespace: opts.CertManager.IssuanceConfigMapNamespace,
 
 				CertificateFileName: opts.Volume.CertificateFileName,
 				KeyFileName:         opts.Volume.KeyFileName,

--- a/internal/csi/app/options/options.go
+++ b/internal/csi/app/options/options.go
@@ -56,6 +56,12 @@ type OptionsDriver struct {
 
 // OptionsCertManager is options specific to cert-manager CertificateRequests.
 type OptionsCertManager struct {
+	// IssuanceConfigMapName is the name of a ConfigMap to watch for configuration options. The ConfigMap is expected to be in the same namespace as the csi-driver-spiffe pod.
+	IssuanceConfigMapName string
+
+	// IssuanceConfigMapNamespace is the namespace where the runtime configuration ConfigMap is located
+	IssuanceConfigMapNamespace string
+
 	// TrustDomain is the trust domain of this SPIFFE PKI. The TrustDomain will
 	// appear in signed certificate's URI SANs.
 	TrustDomain string
@@ -113,6 +119,10 @@ func (o *Options) addDriverFlags(fs *pflag.FlagSet) {
 }
 
 func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.CertManager.IssuanceConfigMapName, "runtime-issuance-config-map-name", "", "Name of a ConfigMap to watch at runtime for issuer details. If such a ConfigMap is found, overrides issuer-name, issuer-kind and issuer-group")
+
+	fs.StringVar(&o.CertManager.IssuanceConfigMapNamespace, "runtime-issuance-config-map-namespace", "", "Namespace for ConfigMap to be watched at runtime for issuer details")
+
 	fs.StringVar(&o.CertManager.TrustDomain, "trust-domain", "cluster.local",
 		"The trust domain that will be requested for on created CertificateRequests.")
 	fs.DurationVar(&o.CertManager.CertificateRequestDuration, "certificate-request-duration", time.Hour,

--- a/test/e2e/framework/config/config.go
+++ b/test/e2e/framework/config/config.go
@@ -48,6 +48,9 @@ type Config struct {
 	IssuerSecretName      string
 	RestConfig            *rest.Config
 	KubectlBinPath        string
+
+	IssuanceConfigMapName      string
+	IssuanceConfigMapNamespace string
 }
 
 func (c *Config) AddFlags(fs *flag.FlagSet) *Config {
@@ -89,5 +92,7 @@ func (c *Config) addFlags(fs *flag.FlagSet) *Config {
 	fs.StringVar(&c.IssuerRef.Group, "issuer-group", "cert-manager.io", "Group of issuer which has been created for the test")
 	fs.StringVar(&c.IssuerSecretName, "issuer-secret-name", "csi-driver-spiffe-ca", "Name of the CA certificate Secret")
 	fs.StringVar(&c.IssuerSecretNamespace, "issuer-secret-namespace", "cert-manager", "Namespace where the CA certificate Secret is stored")
+	fs.StringVar(&c.IssuanceConfigMapName, "runtime-issuance-config-map-name", "runtime-config-map", "Name of runtime issuance ConfigMap")
+	fs.StringVar(&c.IssuanceConfigMapNamespace, "runtime-issuance-config-map-namespace", "cert-manager", "Namespace for runtime issuance ConfigMap")
 	return c
 }

--- a/test/e2e/suite/import.go
+++ b/test/e2e/suite/import.go
@@ -20,4 +20,5 @@ import (
 	_ "github.com/cert-manager/csi-driver-spiffe/test/e2e/suite/approval"
 	_ "github.com/cert-manager/csi-driver-spiffe/test/e2e/suite/carotation"
 	_ "github.com/cert-manager/csi-driver-spiffe/test/e2e/suite/fsgroup"
+	_ "github.com/cert-manager/csi-driver-spiffe/test/e2e/suite/runtimeconfiguration"
 )

--- a/test/e2e/suite/runtimeconfiguration/runtimeconfiguration.go
+++ b/test/e2e/suite/runtimeconfiguration/runtimeconfiguration.go
@@ -1,0 +1,369 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeconfiguration
+
+import (
+	"time"
+
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/cert-manager/csi-driver-spiffe/test/e2e/framework"
+	"github.com/cert-manager/csi-driver-spiffe/test/e2e/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	mountPath     = "/var/run/secrets/my-pod"
+	containerName = "my-container"
+)
+
+var _ = framework.CasesDescribe("RuntimeConfiguration", func() {
+	f := framework.NewDefaultFramework("RuntimeConfiguration")
+
+	var (
+		serviceAccount corev1.ServiceAccount
+		role           rbacv1.Role
+		rolebinding    rbacv1.RoleBinding
+		podTemplate    corev1.Pod
+	)
+
+	JustBeforeEach(func() {
+		By("Creating test resources")
+
+		serviceAccount = corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Namespace: f.Namespace.Name, GenerateName: "csi-driver-spiffe-e2e-sa-"},
+		}
+		Expect(f.Client().Create(f.Context(), &serviceAccount)).NotTo(HaveOccurred())
+
+		role = rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "csi-driver-spiffe-e2e-role-",
+				Namespace:    f.Namespace.Name,
+			},
+			Rules: []rbacv1.PolicyRule{{
+				Verbs:     []string{"create"},
+				APIGroups: []string{"cert-manager.io"},
+				Resources: []string{"certificaterequests"},
+			}},
+		}
+		Expect(f.Client().Create(f.Context(), &role)).NotTo(HaveOccurred())
+
+		rolebinding = rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "csi-driver-spiffe-e2e-rolebinding-",
+				Namespace:    f.Namespace.Name,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     role.Name,
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount.Name,
+				Namespace: f.Namespace.Name,
+			}},
+		}
+		Expect(f.Client().Create(f.Context(), &rolebinding)).NotTo(HaveOccurred())
+
+		podTemplate = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-pod-",
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: serviceAccount.Name,
+				Volumes: []corev1.Volume{{
+					Name: "csi-driver-spiffe",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           "spiffe.csi.cert-manager.io",
+							ReadOnly:         ptr.To(true),
+							VolumeAttributes: map[string]string{},
+						},
+					},
+				}},
+				Containers: []corev1.Container{
+					{
+						Name:            containerName,
+						Image:           "docker.io/library/busybox:1.36.1-musl",
+						ImagePullPolicy: corev1.PullNever,
+						Command:         []string{"sleep", "10000"},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "csi-driver-spiffe",
+								MountPath: mountPath,
+							},
+						},
+					},
+				},
+			},
+		}
+
+	})
+
+	JustAfterEach(func() {
+		By("Cleaning up test resources")
+		Expect(f.Client().Delete(f.Context(), &rolebinding)).NotTo(HaveOccurred())
+		Expect(f.Client().Delete(f.Context(), &role)).NotTo(HaveOccurred())
+		Expect(f.Client().Delete(f.Context(), &serviceAccount)).NotTo(HaveOccurred())
+	})
+
+	It("should succeed with a simple pod and no runtime configuration", func() {
+		pod := *podTemplate.DeepCopy()
+
+		Expect(f.Client().Create(f.Context(), &pod)).NotTo(HaveOccurred())
+		defer func() {
+			Expect(f.Client().Delete(f.Context(), &pod)).NotTo(HaveOccurred())
+		}()
+
+		Expect(util.WaitForPodReady(f, &pod)).NotTo(HaveOccurred())
+
+		bundle, err := util.ReadCertFromMountPath(f, mountPath, pod.Name, containerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(bundle.CheckNotEmpty()).NotTo(HaveOccurred())
+	})
+
+	It("should succeed with a new issuer configured at runtime and revert when runtime configuration is deleted", func() {
+		// podOne should be created with the old issuer, since no ConfigMap has been created yet
+		By("Creating a pod before any runtime configuration")
+		podOne := *podTemplate.DeepCopy()
+
+		Expect(f.Client().Create(f.Context(), &podOne)).NotTo(HaveOccurred())
+		defer func() {
+			Expect(f.Client().Delete(f.Context(), &podOne)).NotTo(HaveOccurred())
+		}()
+
+		Expect(util.WaitForPodReady(f, &podOne)).NotTo(HaveOccurred())
+
+		By("Checking the pod used the issuer configured on startup")
+		cliArgCertBundle, err := util.ReadCertFromSecret(f, f.Config().IssuerSecretName, f.Config().IssuerSecretNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		cliArgCert, err := pki.DecodeX509CertificateBytes(cliArgCertBundle.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		podOneBundle, err := util.ReadCertFromMountPath(f, mountPath, podOne.Name, containerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		podOneChain, err := pki.DecodeX509CertificateChainBytes(podOneBundle.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(podOneChain[0].CheckSignatureFrom(cliArgCert)).NotTo(HaveOccurred())
+
+		By("Creating a new issuer to use at runtime")
+		issuerRef, newCABundle, cleanup, err := util.CreateNewCAIssuer(f)
+		defer func() {
+			err := cleanup()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		Expect(err).NotTo(HaveOccurred())
+
+		newCACert, err := pki.DecodeX509CertificateBytes(newCABundle.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		runtimeConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      f.Config().IssuanceConfigMapName,
+				Namespace: f.Config().IssuanceConfigMapNamespace,
+			},
+			Data: map[string]string{
+				"issuer-name":  issuerRef.Name,
+				"issuer-kind":  issuerRef.Kind,
+				"issuer-group": issuerRef.Group,
+			},
+		}
+
+		By("Creating runtime configuration to point at the new issuer")
+		Expect(f.Client().Create(f.Context(), runtimeConfigMap)).NotTo(HaveOccurred())
+
+		configMapNeedsCleanup := true
+		defer func() {
+			if configMapNeedsCleanup {
+				Expect(f.Client().Delete(f.Context(), runtimeConfigMap)).NotTo(HaveOccurred())
+			}
+		}()
+
+		By("Waiting a little for runtime configuration to propagate")
+		time.Sleep(5 * time.Second)
+
+		// now we've created the runtime configuration configmap, a newly created pod should
+		// use the new issuer
+
+		By("Creating a second pod after runtime configuration was created")
+		podTwo := *podTemplate.DeepCopy()
+
+		Expect(f.Client().Create(f.Context(), &podTwo)).NotTo(HaveOccurred())
+		defer func() {
+			Expect(f.Client().Delete(f.Context(), &podTwo)).NotTo(HaveOccurred())
+		}()
+
+		Expect(util.WaitForPodReady(f, &podTwo)).NotTo(HaveOccurred())
+
+		By("Checking that the second pod used the new issuer")
+		podTwoBundle, err := util.ReadCertFromMountPath(f, mountPath, podTwo.Name, containerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		podTwoChain, err := pki.DecodeX509CertificateChainBytes(podTwoBundle.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(podTwoChain[0].CheckSignatureFrom(cliArgCert)).To(HaveOccurred())
+		Expect(podTwoChain[0].CheckSignatureFrom(newCACert)).NotTo(HaveOccurred())
+
+		By("Deleting the configuration ConfigMap")
+		Expect(f.Client().Delete(f.Context(), runtimeConfigMap)).NotTo(HaveOccurred())
+		// we explicitly deleted the ConfigMap as part of the test - no need to clean it up any more
+		configMapNeedsCleanup = false
+
+		By("Waiting a little for runtime configuration to revert")
+		time.Sleep(5 * time.Second)
+
+		By("Creating a third pod after runtime configuration was deleted")
+		podThree := *podTemplate.DeepCopy()
+
+		Expect(f.Client().Create(f.Context(), &podThree)).NotTo(HaveOccurred())
+		defer func() {
+			Expect(f.Client().Delete(f.Context(), &podThree)).NotTo(HaveOccurred())
+		}()
+
+		Expect(util.WaitForPodReady(f, &podThree)).NotTo(HaveOccurred())
+
+		By("Checking that the third pod used the original issuer")
+		podThreeBundle, err := util.ReadCertFromMountPath(f, mountPath, podThree.Name, containerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		podThreeChain, err := pki.DecodeX509CertificateChainBytes(podThreeBundle.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(podThreeChain[0].CheckSignatureFrom(newCACert)).To(HaveOccurred())
+		Expect(podThreeChain[0].CheckSignatureFrom(cliArgCert)).NotTo(HaveOccurred())
+	})
+
+	It("should succeed with a new issuer configured at runtime and change issuers when configuration is updated", func() {
+		// First, fetch the cert for the CLI arg, to check later that it wasn't used to sign any pod certificates
+		cliArgCertBundle, err := util.ReadCertFromSecret(f, f.Config().IssuerSecretName, f.Config().IssuerSecretNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		cliArgCert, err := pki.DecodeX509CertificateBytes(cliArgCertBundle.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a new issuer to use at runtime")
+		issuerRefOne, newCABundleOne, cleanupIssuerOne, err := util.CreateNewCAIssuer(f)
+		defer func() {
+			err := cleanupIssuerOne()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		Expect(err).NotTo(HaveOccurred())
+
+		newCACertOne, err := pki.DecodeX509CertificateBytes(newCABundleOne.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		runtimeConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      f.Config().IssuanceConfigMapName,
+				Namespace: f.Config().IssuanceConfigMapNamespace,
+			},
+			Data: map[string]string{
+				"issuer-name":  issuerRefOne.Name,
+				"issuer-kind":  issuerRefOne.Kind,
+				"issuer-group": issuerRefOne.Group,
+			},
+		}
+
+		By("Creating runtime configuration to point at the new issuer")
+		Expect(f.Client().Create(f.Context(), runtimeConfigMap)).NotTo(HaveOccurred())
+
+		defer func() {
+			Expect(f.Client().Delete(f.Context(), runtimeConfigMap)).NotTo(HaveOccurred())
+		}()
+
+		By("Waiting a little for runtime configuration to propagate")
+		time.Sleep(5 * time.Second)
+
+		By("Creating a pod which uses runtime configuration")
+		podOne := *podTemplate.DeepCopy()
+
+		Expect(f.Client().Create(f.Context(), &podOne)).NotTo(HaveOccurred())
+		defer func() {
+			Expect(f.Client().Delete(f.Context(), &podOne)).NotTo(HaveOccurred())
+		}()
+
+		Expect(util.WaitForPodReady(f, &podOne)).NotTo(HaveOccurred())
+
+		By("Checking the pod used the new issuer")
+		podOneBundle, err := util.ReadCertFromMountPath(f, mountPath, podOne.Name, containerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		podOneChain, err := pki.DecodeX509CertificateChainBytes(podOneBundle.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(podOneChain[0].CheckSignatureFrom(cliArgCert)).To(HaveOccurred())
+		Expect(podOneChain[0].CheckSignatureFrom(newCACertOne)).NotTo(HaveOccurred())
+
+		By("Creating a second new issuer to use at runtime")
+		issuerRefTwo, newCABundleTwo, cleanupIssuerTwo, err := util.CreateNewCAIssuer(f)
+		defer func() {
+			err := cleanupIssuerTwo()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		Expect(err).NotTo(HaveOccurred())
+
+		newCACertTwo, err := pki.DecodeX509CertificateBytes(newCABundleTwo.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		runtimeConfigMap.Data["issuer-name"] = issuerRefTwo.Name
+		runtimeConfigMap.Data["issuer-kind"] = issuerRefTwo.Kind
+		runtimeConfigMap.Data["issuer-group"] = issuerRefTwo.Group
+
+		By("Updating runtime configuration to point at the new issuer")
+		Expect(f.Client().Update(f.Context(), runtimeConfigMap)).NotTo(HaveOccurred())
+
+		By("Waiting a little for the runtime configuration update to propagate")
+		time.Sleep(5 * time.Second)
+
+		By("Creating a second pod after runtime configuration was updated")
+		podTwo := *podTemplate.DeepCopy()
+
+		Expect(f.Client().Create(f.Context(), &podTwo)).NotTo(HaveOccurred())
+		defer func() {
+			Expect(f.Client().Delete(f.Context(), &podTwo)).NotTo(HaveOccurred())
+		}()
+
+		Expect(util.WaitForPodReady(f, &podTwo)).NotTo(HaveOccurred())
+
+		By("Checking that the second pod used the new issuer")
+		podTwoBundle, err := util.ReadCertFromMountPath(f, mountPath, podTwo.Name, containerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		podTwoChain, err := pki.DecodeX509CertificateChainBytes(podTwoBundle.CertificatePEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(podTwoChain[0].CheckSignatureFrom(cliArgCert)).To(HaveOccurred())
+		Expect(podTwoChain[0].CheckSignatureFrom(newCACertOne)).To(HaveOccurred())
+		Expect(podTwoChain[0].CheckSignatureFrom(newCACertTwo)).NotTo(HaveOccurred())
+	})
+})

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -146,21 +146,23 @@ func ReadCertFromMountPath(f *framework.Framework, mountPath string, podName str
 	return bundle, nil
 }
 
-// IssuerCleanupFunc is called to clean up issuer related resources after a test. A returned
-// Any returned cleanup function should always be safe to call and should always be called at some point after the returning function
-// regardless of whether that function returned an error or not
+// IssuerCleanupFunc is called to clean up issuer related resources after a test. Any returned
+// cleanup function should always be safe to call and should always be called at some point after
+// the returning function regardless of whether that function returned an error or not
 type IssuerCleanupFunc func() error
 
-// dummyIssuerCleanupFunc should be returned by functions which return an IssuerCleanupFunc where there's nothing to clean up
-// (e.g. if a fatal error happened before any resources were created).
+// dummyIssuerCleanupFunc should be returned by functions which return an IssuerCleanupFunc where
+// there's nothing to clean up (e.g. if a fatal error happened before any resources were created).
 func dummyIssuerCleanupFunc() error {
 	return nil
 }
 
-// CreateSelfSignedIssuer creates a SelfSigned ClusterIssuer which can be used to in-turn create CA issuers for tests.
-// Returns an issuerRef for the issuer and a cleanup function to remove the issuer after the test completes.
-// The cleanup function is always safe to call and should always be called after this function returns, regardless of
-// whether it returned an error or not
+// CreateSelfSignedIssuer creates a SelfSigned ClusterIssuer which can be used to in-turn create CA
+// issuers for tests.
+// Returns an issuerRef for the issuer and a cleanup function to remove the issuer after the test
+// completes.
+// The cleanup function is always safe to call and should always be called after this function
+// returns, regardless of whether it returned an error or not
 func CreateSelfSignedIssuer(f *framework.Framework) (*cmmeta.ObjectReference, IssuerCleanupFunc, error) {
 	iss := &cmapi.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -191,10 +193,12 @@ func CreateSelfSignedIssuer(f *framework.Framework) (*cmmeta.ObjectReference, Is
 	return issuerRef, cleanupFunc, nil
 }
 
-// CreateNewCAIssuer creates an issuer which can be used for an end-to-end test and cleaned up afterwards.
-// Returns an issuerRef for the issuer, a bundle containing the issuer's data and a function to clean up all issuer resources.
-// The cleanup function is always safe to call and should always be called after this function returns, regardless of
-// whether it returned an error or not
+// CreateNewCAIssuer creates an issuer which can be used for an end-to-end test and cleaned up
+// afterwards.
+// Returns an issuerRef for the issuer, a bundle containing the issuer's data and a function to
+// clean up all issuer resources.
+// The cleanup function is always safe to call and should always be called after this function
+// returns, regardless of whether it returned an error or not
 func CreateNewCAIssuer(f *framework.Framework) (*cmmeta.ObjectReference, *CertBundle, IssuerCleanupFunc, error) {
 	var objectsForCleanup []client.Object
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -23,9 +23,15 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
+	cmapiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8srand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -138,4 +144,262 @@ func ReadCertFromMountPath(f *framework.Framework, mountPath string, podName str
 	}
 
 	return bundle, nil
+}
+
+// IssuerCleanupFunc is called to clean up issuer related resources after a test. A returned
+// Any returned cleanup function should always be safe to call and should always be called at some point after the returning function
+// regardless of whether that function returned an error or not
+type IssuerCleanupFunc func() error
+
+// dummyIssuerCleanupFunc should be returned by functions which return an IssuerCleanupFunc where there's nothing to clean up
+// (e.g. if a fatal error happened before any resources were created).
+func dummyIssuerCleanupFunc() error {
+	return nil
+}
+
+// CreateSelfSignedIssuer creates a SelfSigned ClusterIssuer which can be used to in-turn create CA issuers for tests.
+// Returns an issuerRef for the issuer and a cleanup function to remove the issuer after the test completes.
+// The cleanup function is always safe to call and should always be called after this function returns, regardless of
+// whether it returned an error or not
+func CreateSelfSignedIssuer(f *framework.Framework) (*cmmeta.ObjectReference, IssuerCleanupFunc, error) {
+	iss := &cmapi.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "selfsigned-clusterissuer-",
+		},
+		Spec: cmapi.IssuerSpec{
+			IssuerConfig: cmapi.IssuerConfig{
+				SelfSigned: &cmapi.SelfSignedIssuer{},
+			},
+		},
+	}
+
+	err := f.Client().Create(f.Context(), iss)
+	if err != nil {
+		return nil, dummyIssuerCleanupFunc, err
+	}
+
+	cleanupFunc := func() error {
+		return f.Client().Delete(f.Context(), iss)
+	}
+
+	issuerRef := &cmmeta.ObjectReference{
+		Name:  iss.Name,
+		Kind:  "ClusterIssuer",
+		Group: "cert-manager.io",
+	}
+
+	return issuerRef, cleanupFunc, nil
+}
+
+// CreateNewCAIssuer creates an issuer which can be used for an end-to-end test and cleaned up afterwards.
+// Returns an issuerRef for the issuer, a bundle containing the issuer's data and a function to clean up all issuer resources.
+// The cleanup function is always safe to call and should always be called after this function returns, regardless of
+// whether it returned an error or not
+func CreateNewCAIssuer(f *framework.Framework) (*cmmeta.ObjectReference, *CertBundle, IssuerCleanupFunc, error) {
+	var objectsForCleanup []client.Object
+
+	selfSignedIssuerRef, selfSignedCleanupFunc, err := CreateSelfSignedIssuer(f)
+	if err != nil {
+		return nil, nil, selfSignedCleanupFunc, fmt.Errorf("failed to create selfsigned ClusterIssuer: %s", err)
+	}
+
+	cleanupFunc := func() error {
+		var errs []error
+
+		selfSignedCleanupErr := selfSignedCleanupFunc()
+		if selfSignedCleanupErr != nil {
+			errs = append(errs, selfSignedCleanupErr)
+		}
+
+		for _, m := range objectsForCleanup {
+			err := f.Client().Delete(f.Context(), m)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		return errors.Join(errs...)
+	}
+
+	certSecretName := fmt.Sprintf("e2e-root-%s", k8srand.String(6))
+
+	cert := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      certSecretName,
+			Namespace: "cert-manager", // TODO: this might not always be the case
+		},
+		Spec: cmapi.CertificateSpec{
+			CommonName: certSecretName,
+			IsCA:       true,
+			PrivateKey: &cmapi.CertificatePrivateKey{
+				Algorithm: cmapi.ECDSAKeyAlgorithm,
+				Size:      256,
+			},
+			SecretName: certSecretName,
+			IssuerRef:  *selfSignedIssuerRef,
+		},
+	}
+
+	err = f.Client().Create(f.Context(), cert)
+	if err != nil {
+		return nil, nil, cleanupFunc, err
+	}
+
+	objectsForCleanup = append(objectsForCleanup, cert)
+
+	err = approveCertificateRequestsForCertificate(f, cert)
+	if err != nil {
+		return nil, nil, cleanupFunc, fmt.Errorf("failed to approve CertificateRequest: %s", err)
+	}
+
+	err = WaitForCertificateReady(f, cert)
+	if err != nil {
+		return nil, nil, cleanupFunc, fmt.Errorf("failed to wait for cert to become ready: %s", err)
+	}
+
+	iss := &cmapi.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("ca-issuer-%s", certSecretName),
+		},
+		Spec: cmapi.IssuerSpec{
+			IssuerConfig: cmapi.IssuerConfig{
+				CA: &cmapi.CAIssuer{
+					SecretName: cert.Spec.SecretName,
+				},
+			},
+		},
+	}
+
+	err = f.Client().Create(f.Context(), iss)
+	if err != nil {
+		return nil, nil, cleanupFunc, err
+	}
+
+	objectsForCleanup = append(objectsForCleanup, iss)
+
+	caBundle, err := ReadCertFromSecret(f, certSecretName, "cert-manager")
+	if err != nil {
+		return nil, nil, cleanupFunc, err
+	}
+
+	newIssuerRef := cmmeta.ObjectReference{
+		Name:  iss.Name,
+		Kind:  "ClusterIssuer",
+		Group: "cert-manager.io",
+	}
+
+	return &newIssuerRef, caBundle, cleanupFunc, nil
+}
+
+// ReadCertFromSecret loads a certificate bundle from a Secret resource
+func ReadCertFromSecret(f *framework.Framework, secretName string, secretNamespace string) (*CertBundle, error) {
+	certSecret := &corev1.Secret{}
+
+	key := client.ObjectKey{
+		Name:      secretName,
+		Namespace: secretNamespace,
+	}
+
+	err := f.Client().Get(f.Context(), key, certSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch secret %s/%s: %s", secretNamespace, secretName, err)
+	}
+
+	chainBytes, exists := certSecret.Data["tls.crt"]
+	if !exists {
+		return nil, fmt.Errorf("failed to find certificate chain in secret %s/%s", secretNamespace, secretName)
+	}
+
+	privateKeyBytes, exists := certSecret.Data["tls.key"]
+	if !exists {
+		return nil, fmt.Errorf("failed to find private key in secret %s/%s", secretNamespace, secretName)
+	}
+
+	caBytes, exists := certSecret.Data["ca.crt"]
+	if !exists {
+		return nil, fmt.Errorf("failed to find CA data in secret %s/%s", secretNamespace, secretName)
+	}
+
+	return &CertBundle{
+		CertificatePEM: chainBytes,
+		PrivateKeyPEM:  privateKeyBytes,
+		CAPEM:          caBytes,
+	}, nil
+}
+
+// WaitForCertificateReady waits until the references Certificate resource is marked as ready
+func WaitForCertificateReady(f *framework.Framework, cert *cmapi.Certificate) error {
+	timeout := 60 * time.Second
+	interval := 2 * time.Second
+	immediate := false
+
+	return wait.PollUntilContextTimeout(f.Context(), interval, timeout, immediate, func(ctx context.Context) (bool, error) {
+		err := f.Client().Get(ctx, client.ObjectKeyFromObject(cert), cert)
+		if err != nil {
+			return false, err
+		}
+
+		for _, cond := range cert.Status.Conditions {
+			if cond.Type != cmapi.CertificateConditionReady {
+				continue
+			}
+
+			return cond.Status == cmmeta.ConditionTrue, nil
+		}
+
+		return false, nil
+	})
+}
+
+func approveCertificateRequestsForCertificate(f *framework.Framework, cert *cmapi.Certificate) error {
+	crList := &cmapi.CertificateRequestList{}
+
+	listOpts := &client.ListOptions{
+		Namespace: cert.Namespace,
+	}
+
+	timeout := 10 * time.Second
+	interval := 1 * time.Second
+	immediate := false
+
+	err := wait.PollUntilContextTimeout(f.Context(), interval, timeout, immediate, func(ctx context.Context) (bool, error) {
+		err := f.Client().List(ctx, crList, listOpts)
+		if err != nil {
+			return false, err
+		}
+
+		for _, cr := range crList.Items {
+			if strings.HasPrefix(cr.Name, cert.Name) {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for CertificateRequest to be created: %s", err)
+	}
+
+	var updateErrs []error
+
+	for _, cr := range crList.Items {
+		cr := cr
+
+		if !strings.HasPrefix(cr.Name, cert.Name) {
+			continue
+		}
+
+		cmapiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "csi-driver-spiffe-e2e-test", "Manually approved for csi-driver-spiffe e2e tests")
+
+		err := f.Client().Status().Update(f.Context(), &cr)
+		if err != nil {
+			updateErrs = append(updateErrs, err)
+		}
+	}
+
+	if len(updateErrs) > 0 {
+		return errors.Join(updateErrs...)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Currently, installing csi-driver-spiffe requires that users have already installed cert-manager and already created an issuer, because issuer config must be passed in at startup.

This presents problems when users wish to install everything and configure it later. It also means that it's not possible to change issuers without risking downtime of the driver, which in turn implies downtime in being able to create any pod which relies on csi-driver-spiffe.

This PR adds support for runtime configuration through a ConfigMap. If enabled, the ConfigMap will be watched and if it exists and the configuration is value, the issuer specified in that ConfigMap will override any issuer configured at runtime.

To support the e2e tests for this, we also add lots of helper functions for generating issuers for e2e tests and retrieving certificate details from pods without copy+pasting boilerplate test code.

EDIT: I forgot to link [the design doc](https://github.com/cert-manager/csi-driver-spiffe/blob/84f88f14ad564e4b01a0be9b7ca861c2bec9ba5c/design/2024-02-21-install-without-issuer.md) which this PR implements.