### PR TITLE
Tweak camanager testing

### DIFF
--- a/internal/csi/driver/camanager.go
+++ b/internal/csi/driver/camanager.go
@@ -107,7 +107,7 @@ func (c *camanager) run(ctx context.Context, updateRetryPeriod time.Duration) {
 				// Retry updating the root CA files.
 				go func() {
 					select {
-					// Wait for 5 seconds before retrying.
+					// Wait before retrying.
 					case <-time.After(updateRetryPeriod):
 					case <-ctx.Done():
 						return

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -234,7 +234,8 @@ func (d *Driver) Run(ctx context.Context) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		d.camanager.run(ctx, time.Second*5)
+		updateRetryPeriod := time.Second * 5
+		d.camanager.run(ctx, updateRetryPeriod)
 	}()
 
 	wg.Add(1)


### PR DESCRIPTION
Because we set the update retry period to 5s, polling every second is wasteful as that's 5x faster than the retry period.

That logic also implies that a timeout of 60s is very short, since that's only at most 12 attempts for the update to succeed. Anecdotal evidence shows that this leads to a lot of flaked tests.

This commit increases that timeout to reduce flakes.

It also changes how the test works to clean up after it modifies global state, and to compare strings rather than byte slices which makes error output much easier to read if there's a problem.