### PR TITLE
Add Helm chart OCI release to GH automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ env:
   VERSION: ${{ github.ref_name }}
 
 jobs:
-  build_images:
+  build_and_push:
     runs-on: ubuntu-latest
 
     permissions:
@@ -36,24 +36,18 @@ jobs:
       - id: release
         run: make release
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.release.outputs.RELEASE_HELM_CHART_NAME }}-${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}.tgz
-          path: ${{ steps.release.outputs.RELEASE_HELM_CHART_TAR }}
-          if-no-files-found: error
-
     outputs:
       RELEASE_OCI_MANAGER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_IMAGE }}
       RELEASE_OCI_MANAGER_TAG: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_TAG }}
       RELEASE_OCI_APPROVER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_APPROVER_IMAGE }}
       RELEASE_OCI_APPROVER_TAG: ${{ steps.release.outputs.RELEASE_OCI_APPROVER_TAG }}
-      RELEASE_HELM_CHART_NAME: ${{ steps.release.outputs.RELEASE_HELM_CHART_NAME }}
+      RELEASE_HELM_CHART_IMAGE: ${{ steps.release.outputs.RELEASE_HELM_CHART_IMAGE }}
       RELEASE_HELM_CHART_VERSION: ${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}
 
   github_release:
     runs-on: ubuntu-latest
 
-    needs: build_images
+    needs: build_and_push
 
     permissions:
       contents: write # needed for creating a PR
@@ -62,17 +56,12 @@ jobs:
     steps:
       - run: |
           touch .notes-file
-          echo "OCI_MANAGER_IMAGE: ${{ needs.build_images.outputs.RELEASE_OCI_MANAGER_IMAGE }}" >> .notes-file
-          echo "OCI_MANAGER_TAG: ${{ needs.build_images.outputs.RELEASE_OCI_MANAGER_TAG }}" >> .notes-file
-          echo "OCI_APPROVER_IMAGE: ${{ needs.build_images.outputs.RELEASE_OCI_APPROVER_IMAGE }}" >> .notes-file
-          echo "OCI_APPROVER_TAG: ${{ needs.build_images.outputs.RELEASE_OCI_APPROVER_TAG }}" >> .notes-file
-          echo "HELM_CHART_NAME: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}" >> .notes-file
-          echo "HELM_CHART_VERSION: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
-
-      - id: chart_download
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}-${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}.tgz
+          echo "OCI_MANAGER_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_OCI_MANAGER_IMAGE }}" >> .notes-file
+          echo "OCI_MANAGER_TAG: ${{ needs.build_and_push.outputs.RELEASE_OCI_MANAGER_TAG }}" >> .notes-file
+          echo "OCI_APPROVER_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_OCI_APPROVER_IMAGE }}" >> .notes-file
+          echo "OCI_APPROVER_TAG: ${{ needs.build_and_push.outputs.RELEASE_OCI_APPROVER_TAG }}" >> .notes-file
+          echo "HELM_CHART_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_IMAGE }}" >> .notes-file
+          echo "HELM_CHART_VERSION: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
 
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,7 +72,3 @@ jobs:
             --draft \
             --verify-tag \
             --notes-file .notes-file
-          
-          gh release upload "$VERSION" \
-            --repo="$GITHUB_REPOSITORY" \
-            "${{ steps.chart_download.outputs.download-path }}/${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}-${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}.tgz"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,24 +18,21 @@ The release process for this repo is documented below:
    ```
 2. A GitHub action will see the new tag and do the following:
     - Build and publish any container images
-    - Build and bundle the Helm chart
+    - Build and publish the Helm chart
     - Create a draft GitHub release
-    - Upload the Helm chart tarball to the GitHub release
-3. Once the draft GitHub release has been created, download and test the resulting Helm chart.
-4. Create a PR in the [jetstack/jetstack-charts repository on GitHub](https://github.com/jetstack/jetstack-charts), containing the Helm chart file that is attached to the draft GitHub release. This is only currently possible for maintainers inside Venafi, but will be changed in the future.
-5. Wait for the PR to be merged and verify that the Helm chart is available from https://charts.jetstack.io.
-6. Visit the [releases page], edit the draft release, click "Generate release notes", then edit the notes to add the following to the top
+3. Wait for the PR to be merged and wait for OCI Helm chart to propagate and become available from https://charts.jetstack.io (this might take a few hours).
+4. Visit the [releases page], edit the draft release, click "Generate release notes", then edit the notes to add the following to the top
     ```
     csi-driver-spiffe is a clean and simple way to get SPIFFE IDs for your Kubernetes pods with minimal dependencies and minimal fuss.
     ```
-7. Publish the release.
+5. Publish the release.
 
 ## Artifacts
 
 This repo will produce the following artifacts each release. For documentation on how those artifacts are produced see the "Process" section.
 
-- *Container Images* - Container images for the are published to . 
-- *Helm chart* - An official Helm chart is maintained within this repo and published to `charts.jetstack.io` on each release.
+- *Container Images* - Container images for the are published to `quay.io/jetstack`. 
+- *Helm chart* - An official Helm chart is maintained within this repo and published to `quay.io/jetstack` and `charts.jetstack.io` on each release.
 
 [release workflow]: https://github.com/cert-manager/csi-driver-spiffe/actions/workflows/release.yaml
 [releases page]: https://github.com/cert-manager/csi-driver-spiffe/releases

--- a/klone.yaml
+++ b/klone.yaml
@@ -35,7 +35,7 @@ targets:
     - folder_name: helm
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 25ec11345ab139986fad5fe7ffb5503069e6f81b
+      repo_hash: fbd26411777b12c2574d05f146cee617c6c50b63
       repo_path: modules/helm
     - folder_name: help
       repo_url: https://github.com/cert-manager/makefile-modules.git

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -43,12 +43,9 @@ api_docs_package := $(repo_name)/pkg/apis/trust/v1alpha1
 api_docs_branch := main
 
 helm_chart_source_dir := deploy/charts/csi-driver-spiffe
-helm_chart_name := cert-manager-csi-driver-spiffe
+helm_chart_image_name := quay.io/jetstack/charts/cert-manager-csi-driver-spiffe
 helm_chart_version := $(VERSION)
 helm_labels_template_name := cert-manager-csi-driver-spiffe.labels
-helm_docs_use_helm_tool := 1
-helm_generate_schema := 1
-helm_verify_values := 1
 
 golangci_lint_config := .golangci.yaml
 

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -23,15 +23,15 @@ include make/test-unit.mk
 .PHONY: release
 ## Publish all release artifacts (image + helm chart)
 ## @category [shared] Release
-release: $(helm_chart_archive)
+release:
 	$(MAKE) oci-push-manager oci-push-approver
+	$(MAKE) helm-chart-oci-push
 
 	@echo "RELEASE_OCI_MANAGER_IMAGE=$(oci_manager_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_MANAGER_TAG=$(oci_manager_image_tag)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_APPROVER_IMAGE=$(oci_manager_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_APPROVER_TAG=$(oci_manager_image_tag)" >> "$(GITHUB_OUTPUT)"
-	@echo "RELEASE_HELM_CHART_NAME=$(helm_chart_name)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_HELM_CHART_IMAGE=$(helm_chart_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_VERSION=$(helm_chart_version)" >> "$(GITHUB_OUTPUT)"
-	@echo "RELEASE_HELM_CHART_TAR=$(helm_chart_archive)" >> "$(GITHUB_OUTPUT)"
 
 	@echo "Release complete!"


### PR DESCRIPTION
Adds logic for pushing the Helm chart to an OCI registry (and adding a non-v-prefixed tag)

See https://github.com/cert-manager/makefile-modules/pull/219 for more info.