### PR TITLE
Fix bad security context on DaemonSet

### DIFF
--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -18,7 +18,6 @@ spec:
         kubectl.kubernetes.io/default-container: cert-manager-csi-driver-spiffe
     spec:
       securityContext:
-        readOnlyRootFilesystem: true
         seccompProfile: { type: RuntimeDefault }
 
       {{- with .Values.imagePullSecrets }}
@@ -33,6 +32,7 @@ spec:
             runAsUser: 0
             allowPrivilegeEscalation: false
             capabilities: { drop: [ "ALL" ] }
+            readOnlyRootFilesystem: true
           image: "{{ template "image" (tuple .Values.app.driver.nodeDriverRegistrarImage $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.app.driver.nodeDriverRegistrarImage.pullPolicy }}
           args:
@@ -55,6 +55,7 @@ spec:
             runAsUser: 0
             allowPrivilegeEscalation: false
             capabilities: { drop: [ "ALL" ] }
+            readOnlyRootFilesystem: true
           image: "{{ template "image" (tuple .Values.app.driver.livenessProbeImage $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.app.driver.livenessProbeImage.pullPolicy }}
           args:
@@ -71,6 +72,7 @@ spec:
             runAsUser: 0
             privileged: true
             capabilities: { drop: [ "ALL" ] }
+            readOnlyRootFilesystem: true
           image: "{{ template "image-driver" (tuple .Values.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args :


### PR DESCRIPTION
This passes locally for me with no errors; this can be merged after the kubeconform tests are added via makefile-modules.

EDIT: This can now be merged, which should unblock #285 