### PR TITLE
Bump sidecar image versions in preparation for release

### DIFF
--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -256,7 +256,7 @@ Target image repository.
 #### **app.driver.nodeDriverRegistrarImage.tag** ~ `string`
 > Default value:
 > ```yaml
-> v2.13.0
+> v2.14.0
 > ```
 
 Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.
@@ -297,7 +297,7 @@ Target image repository.
 #### **app.driver.livenessProbeImage.tag** ~ `string`
 > Default value:
 > ```yaml
-> v2.15.0
+> v2.16.0
 > ```
 
 Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -312,7 +312,7 @@
       "type": "string"
     },
     "helm-values.app.driver.livenessProbeImage.tag": {
-      "default": "v2.15.0",
+      "default": "v2.16.0",
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
       "type": "string"
     },
@@ -356,7 +356,7 @@
       "type": "string"
     },
     "helm-values.app.driver.nodeDriverRegistrarImage.tag": {
-      "default": "v2.13.0",
+      "default": "v2.14.0",
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
       "type": "string"
     },

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -155,7 +155,7 @@ app:
       # Override the image tag to deploy by setting this variable.
       # If no value is set, the chart's appVersion is used.
       # +docs:property
-      tag: v2.15.0
+      tag: v2.16.0
 
       # Target image digest. Override any tag, if set.
       # For example:

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -130,7 +130,7 @@ app:
       # Override the image tag to deploy by setting this variable.
       # If no value is set, the chart's appVersion is used.
       # +docs:property
-      tag: v2.13.0
+      tag: v2.14.0
 
       # Target image digest. Override any tag, if set.
       # For example:


### PR DESCRIPTION
As per https://github.com/cert-manager/csi-driver-spiffe/blob/main/RELEASE.md#preparing-for-a-release
> BEFORE doing a release, check if the other images in the csi-driver Helm chart need to be updated.
> These are:
> registry.k8s.io/sig-storage/livenessprobe (.Values.livenessProbeImage.tag)
> registry.k8s.io/sig-storage/csi-node-driver-registrar (.Values.nodeDriverRegistrarImage.tag)

Artifacthub is showing the vulnerabilities in these two images:
 * https://artifacthub.io/packages/helm/cert-manager/cert-manager-csi-driver-spiffe/0.9.1?modal=security-report


Links:
 * https://github.com/kubernetes-csi/livenessprobe/releases/tag/v2.16.0
 * https://github.com/kubernetes-csi/node-driver-registrar/releases/tag/v2.14.0

Slack thread: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1750949202461539