### PR TITLE
Mark SAN extension critical in SPIFFE CSRs for RFC 5280 and AWS PCA compliance

### DIFF
--- a/internal/csi/driver/driver_test.go
+++ b/internal/csi/driver/driver_test.go
@@ -20,6 +20,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -128,4 +133,45 @@ func Test_DriverAnnotationSanitization(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_signRequest_SAN_critical(t *testing.T) {
+	const spiffeID = "spiffe://example.org/ns/default/sa/workload"
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	spiffeURI, err := url.Parse(spiffeID)
+	require.NoError(t, err)
+
+	csrTemplate := &x509.CertificateRequest{
+		// Subject intentionally left empty — this is the SPIFFE SVID pattern.
+		Subject: pkix.Name{},
+		URIs:    []*url.URL{spiffeURI},
+	}
+
+	csrPEM, err := signRequest(metadata.Metadata{}, key, csrTemplate)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(csrPEM)
+	require.NotNil(t, block, "PEM decode must succeed")
+
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	require.NoError(t, err)
+
+	sanOID := asn1.ObjectIdentifier{2, 5, 29, 17}
+
+	var sanExt *pkix.Extension
+	for i := range csr.Extensions {
+		if csr.Extensions[i].Id.Equal(sanOID) {
+			sanExt = &csr.Extensions[i]
+			break
+		}
+	}
+	require.NotNil(t, sanExt, "CSR must contain the SAN extension (OID 2.5.29.17)")
+	require.True(t, sanExt.Critical, "SAN extension must be critical when subject is empty")
+
+	// Verify the SPIFFE URI is present in the parsed CSR.
+	require.Len(t, csr.URIs, 1)
+	require.Equal(t, spiffeID, csr.URIs[0].String())
 }

--- a/internal/csi/driver/driver_test.go
+++ b/internal/csi/driver/driver_test.go
@@ -135,43 +135,63 @@ func Test_DriverAnnotationSanitization(t *testing.T) {
 	}
 }
 
-func Test_signRequest_SAN_critical(t *testing.T) {
+// Test_signRequest_SAN_criticality checks that signRequest marks the SAN
+// extension (OID 2.5.29.17) critical only when the subject is empty (the
+// SPIFFE SVID case), and leaves it non-critical otherwise — guarding against
+// a regression into unconditionally marking SAN critical.
+func Test_signRequest_SAN_criticality(t *testing.T) {
 	const spiffeID = "spiffe://example.org/ns/default/sa/workload"
-
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
 
 	spiffeURI, err := url.Parse(spiffeID)
 	require.NoError(t, err)
 
-	csrTemplate := &x509.CertificateRequest{
-		// Subject intentionally left empty — this is the SPIFFE SVID pattern.
-		Subject: pkix.Name{},
-		URIs:    []*url.URL{spiffeURI},
+	tests := map[string]struct {
+		subject         pkix.Name
+		wantSANCritical bool
+	}{
+		"empty subject (SPIFFE SVID) marks SAN critical": {
+			subject:         pkix.Name{},
+			wantSANCritical: true,
+		},
+		"non-empty subject leaves SAN non-critical": {
+			subject:         pkix.Name{CommonName: "example-workload"},
+			wantSANCritical: false,
+		},
 	}
 
-	csrPEM, err := signRequest(metadata.Metadata{}, key, csrTemplate)
-	require.NoError(t, err)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
 
-	block, _ := pem.Decode(csrPEM)
-	require.NotNil(t, block, "PEM decode must succeed")
+			csrTemplate := &x509.CertificateRequest{
+				Subject: test.subject,
+				URIs:    []*url.URL{spiffeURI},
+			}
 
-	csr, err := x509.ParseCertificateRequest(block.Bytes)
-	require.NoError(t, err)
+			csrPEM, err := signRequest(metadata.Metadata{}, key, csrTemplate)
+			require.NoError(t, err)
 
-	sanOID := asn1.ObjectIdentifier{2, 5, 29, 17}
+			block, _ := pem.Decode(csrPEM)
+			require.NotNil(t, block, "PEM decode must succeed")
 
-	var sanExt *pkix.Extension
-	for i := range csr.Extensions {
-		if csr.Extensions[i].Id.Equal(sanOID) {
-			sanExt = &csr.Extensions[i]
-			break
-		}
+			csr, err := x509.ParseCertificateRequest(block.Bytes)
+			require.NoError(t, err)
+
+			sanOID := asn1.ObjectIdentifier{2, 5, 29, 17}
+
+			var sanExt *pkix.Extension
+			for i := range csr.Extensions {
+				if csr.Extensions[i].Id.Equal(sanOID) {
+					sanExt = &csr.Extensions[i]
+					break
+				}
+			}
+			require.NotNil(t, sanExt, "CSR must contain the SAN extension (OID 2.5.29.17)")
+			require.Equal(t, test.wantSANCritical, sanExt.Critical)
+
+			require.Len(t, csr.URIs, 1)
+			require.Equal(t, spiffeID, csr.URIs[0].String())
+		})
 	}
-	require.NotNil(t, sanExt, "CSR must contain the SAN extension (OID 2.5.29.17)")
-	require.True(t, sanExt.Critical, "SAN extension must be critical when subject is empty")
-
-	// Verify the SPIFFE URI is present in the parsed CSR.
-	require.Len(t, csr.URIs, 1)
-	require.Equal(t, spiffeID, csr.URIs[0].String())
 }

--- a/internal/csi/driver/util.go
+++ b/internal/csi/driver/util.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/cert-manager/csi-lib/metadata"
+
+	cmpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
 // generatePrivateKey generates an ECDSA private key, which is the only currently supported type
@@ -35,7 +37,27 @@ func generatePrivateKey(_ metadata.Metadata) (crypto.PrivateKey, error) {
 }
 
 // signRequest will sign a given X.509 certificate signing request with the given key.
+// When URI SANs are present and the subject is empty (as with SPIFFE SVIDs),
+// RFC 5280 §4.2.1.6 requires the SAN extension to be marked critical.
+// Go's x509.CreateCertificateRequest does not do this, so we marshal the
+// SAN extension ourselves via cert-manager's MarshalSANs helper.
 func signRequest(_ metadata.Metadata, key crypto.PrivateKey, request *x509.CertificateRequest) ([]byte, error) {
+	if len(request.URIs) > 0 {
+		uriStrings := make([]string, len(request.URIs))
+		for i, u := range request.URIs {
+			uriStrings[i] = u.String()
+		}
+		sans := cmpki.GeneralNames{UniformResourceIdentifiers: uriStrings}
+		// hasSubject=false → Critical=true
+		sanExt, err := cmpki.MarshalSANs(sans, false)
+		if err != nil {
+			return nil, err
+		}
+		request.ExtraExtensions = append(request.ExtraExtensions, sanExt)
+		// Clear URIs to avoid a duplicate SAN extension from the stdlib.
+		request.URIs = nil
+	}
+
 	csrDer, err := x509.CreateCertificateRequest(rand.Reader, request, key)
 	if err != nil {
 		return nil, err

--- a/internal/csi/driver/util.go
+++ b/internal/csi/driver/util.go
@@ -22,13 +22,13 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"time"
 
-	"github.com/cert-manager/csi-lib/metadata"
-
 	cmpki "github.com/cert-manager/cert-manager/pkg/util/pki"
+	"github.com/cert-manager/csi-lib/metadata"
 )
 
 // generatePrivateKey generates an ECDSA private key, which is the only currently supported type
@@ -36,19 +36,25 @@ func generatePrivateKey(_ metadata.Metadata) (crypto.PrivateKey, error) {
 	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 }
 
-// signRequest will sign a given X.509 certificate signing request with the given key.
-// When URI SANs are present and the subject is empty (as with SPIFFE SVIDs),
-// RFC 5280 §4.2.1.6 requires the SAN extension to be marked critical.
-// Go's x509.CreateCertificateRequest does not do this, so we marshal the
-// SAN extension ourselves via cert-manager's MarshalSANs helper.
+// signRequest signs the given X.509 certificate request with the given key.
+// RFC 5280 §4.2.1.6 requires the SAN extension to be critical when the subject
+// is empty (as with SPIFFE SVIDs), but x509.CreateCertificateRequest never marks
+// it so; we therefore marshal a critical SAN ourselves via cert-manager's
+// MarshalSANs. A CSR carrying a subject is left to the stdlib (non-critical SAN),
+// though SPIFFE SVIDs should never carry one.
 func signRequest(_ metadata.Metadata, key crypto.PrivateKey, request *x509.CertificateRequest) ([]byte, error) {
-	if len(request.URIs) > 0 {
+	asn1Subject, err := asn1.Marshal(request.Subject.ToRDNSequence())
+	if err != nil {
+		return nil, err
+	}
+
+	if len(request.URIs) > 0 && cmpki.IsASN1SubjectEmpty(asn1Subject) {
 		uriStrings := make([]string, len(request.URIs))
 		for i, u := range request.URIs {
 			uriStrings[i] = u.String()
 		}
 		sans := cmpki.GeneralNames{UniformResourceIdentifiers: uriStrings}
-		// hasSubject=false → Critical=true
+		// no subject, so MarshalSANs marks the SAN critical
 		sanExt, err := cmpki.MarshalSANs(sans, false)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
SPIFFE SVIDs use X.509 certificates with an empty `Subject` field, relying entriely on the URI SAN. [RFC 5280 4.2.1.6](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6) requires the SAN extension to be critical when the subject is empty. However Go's [x509.CreateCertificateRequest](https://pkg.go.dev/crypto/x509#CreateCertificateRequest) always marks the SAN extension as non-critical, regardless of whether the subject is populated.

This causes issuance failures with strict certificate authorities such as AWS Private CA, which rejects CSRs that have an empty subject with a non-critical SAN extension.

Using cert-manager's [pki.MarshalSANs](https://pkg.go.dev/github.com/cert-manager/cert-manager@v1.19.4/pkg/util/pki#MarshalSANs) helper we now correctly set the SAN extension to critical when the subject is empty.

I've validated this builds and runs as expected allowing for the issuance of certificates from AWS PCA.