### PR TITLE
approver: add --auto-approve-non-spiffe flag

### DIFF
--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -489,6 +489,15 @@ Number of replicas of the approver to run.
 > ```
 
 A signer name that the csi-driver-spiffe approver will be given permission to approve and deny. CertificateRequests referencing this signer name can be processed by the SPIFFE approver. See: https://cert-manager.io/docs/concepts/certificaterequest/#approval. Defaults to empty which allows approval for all signers
+#### **app.approver.autoApproveNonSpiffe** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+When enabled, the approver will approve all CertificateRequests that do not target the configured SPIFFE issuer. This allows csi-driver-spiffe to act as a drop-in replacement for cert-manager's default approval controller, removing the need for approver-policy in simple deployments.  
+  
+WARNING: Enabling this grants the approver authority to approve all. CertificateRequests cluster-wide that do not target the SPIFFE issuer. Only enable if cert-manager's built-in auto-approver has been disabled.
 #### **app.approver.readinessProbe.port** ~ `number`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -489,7 +489,7 @@ Number of replicas of the approver to run.
 > ```
 
 A signer name that the csi-driver-spiffe approver will be given permission to approve and deny. CertificateRequests referencing this signer name can be processed by the SPIFFE approver. See: https://cert-manager.io/docs/concepts/certificaterequest/#approval. Defaults to empty which allows approval for all signers
-#### **app.approver.autoApproveNonSpiffe** ~ `bool`
+#### **app.approver.autoApproveNonSPIFFE** ~ `bool`
 > Default value:
 > ```yaml
 > false
@@ -497,7 +497,7 @@ A signer name that the csi-driver-spiffe approver will be given permission to ap
 
 When enabled, the approver will approve all CertificateRequests that do not target the configured SPIFFE issuer. This allows csi-driver-spiffe to act as a drop-in replacement for cert-manager's default approval controller, removing the need for approver-policy in simple deployments.  
   
-WARNING: Enabling this grants the approver authority to approve all. CertificateRequests cluster-wide that do not target the SPIFFE issuer. Only enable if cert-manager's built-in auto-approver has been disabled.
+WARNING: Enabling this grants the approver authority to approve all. CertificateRequests cluster-wide that do not target the SPIFFE issuer.
 #### **app.approver.readinessProbe.port** ~ `number`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -497,7 +497,7 @@ A signer name that the csi-driver-spiffe approver will be given permission to ap
 
 When enabled, the approver will approve all CertificateRequests that do not target the configured SPIFFE issuer. This allows csi-driver-spiffe to act as a drop-in replacement for cert-manager's default approval controller, removing the need for approver-policy in simple deployments.  
   
-WARNING: Enabling this grants the approver authority to approve all. CertificateRequests cluster-wide that do not target the SPIFFE issuer.
+WARNING: Enabling this grants the approver authority to approve all CertificateRequests cluster-wide that do not target the SPIFFE issuer.
 #### **app.approver.readinessProbe.port** ~ `number`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           - "--runtime-issuance-config-map-name={{.Values.app.runtimeIssuanceConfigMap}}"
           - "--runtime-issuance-config-map-namespace={{.Release.Namespace}}"
 
-          {{- if .Values.app.approver.autoApproveNonSpiffe }}
+          {{- if .Values.app.approver.autoApproveNonSPIFFE }}
           - --auto-approve-non-spiffe
           {{- end }}
           - --leader-election-namespace=$(POD_NAMESPACE)

--- a/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
@@ -39,8 +39,17 @@ spec:
           - --csi-driver-name={{ .Values.app.name }}
 
           - --certificate-request-duration={{ .Values.app.certificateRequestDuration }}
+          - --issuer-name={{ .Values.app.issuer.name }}
+          - --issuer-kind={{ .Values.app.issuer.kind }}
+          - --issuer-group={{ .Values.app.issuer.group }}
           - --trust-domain={{ .Values.app.trustDomain }}
 
+          - "--runtime-issuance-config-map-name={{.Values.app.runtimeIssuanceConfigMap}}"
+          - "--runtime-issuance-config-map-namespace={{.Release.Namespace}}"
+
+          {{- if .Values.app.approver.autoApproveNonSpiffe }}
+          - --auto-approve-non-spiffe
+          {{- end }}
           - --leader-election-namespace=$(POD_NAMESPACE)
           - "--metrics-bind-address=:{{.Values.app.approver.metrics.port}}"
           - "--readiness-probe-bind-address=:{{.Values.app.approver.readinessProbe.port}}"

--- a/deploy/charts/csi-driver-spiffe/templates/role.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/role.yaml
@@ -27,3 +27,9 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "update", "create"]
+{{- if .Values.app.runtimeIssuanceConfigMap }}
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+  resourceNames: ["{{.Values.app.runtimeIssuanceConfigMap}}"]
+{{- end }}

--- a/deploy/charts/csi-driver-spiffe/tests/approver-non-spiffe_test.yaml
+++ b/deploy/charts/csi-driver-spiffe/tests/approver-non-spiffe_test.yaml
@@ -2,16 +2,16 @@ suite: test approver non-SPIFFE auto-approval args
 templates:
   - deployment.yaml
 tests:
-  - it: should inject --auto-approve-non-spiffe when autoApproveNonSpiffe is true
+  - it: should inject --auto-approve-non-spiffe when autoApproveNonSPIFFE is true
     template: deployment.yaml
     set:
-      app.approver.autoApproveNonSpiffe: true
+      app.approver.autoApproveNonSPIFFE: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --auto-approve-non-spiffe
 
-  - it: should not inject --auto-approve-non-spiffe when autoApproveNonSpiffe is false (default)
+  - it: should not inject --auto-approve-non-spiffe when autoApproveNonSPIFFE is false (default)
     template: deployment.yaml
     asserts:
       - notContains:

--- a/deploy/charts/csi-driver-spiffe/tests/approver-non-spiffe_test.yaml
+++ b/deploy/charts/csi-driver-spiffe/tests/approver-non-spiffe_test.yaml
@@ -1,0 +1,56 @@
+suite: test approver non-SPIFFE auto-approval args
+templates:
+  - deployment.yaml
+tests:
+  - it: should inject --auto-approve-non-spiffe when autoApproveNonSpiffe is true
+    template: deployment.yaml
+    set:
+      app.approver.autoApproveNonSpiffe: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --auto-approve-non-spiffe
+
+  - it: should not inject --auto-approve-non-spiffe when autoApproveNonSpiffe is false (default)
+    template: deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --auto-approve-non-spiffe
+
+  - it: should always inject issuer flags in approver deployment
+    template: deployment.yaml
+    set:
+      app.issuer.name: spiffe-ca
+      app.issuer.kind: ClusterIssuer
+      app.issuer.group: cert-manager.io
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --issuer-name=spiffe-ca
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --issuer-kind=ClusterIssuer
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --issuer-group=cert-manager.io
+
+  - it: should inject runtime configmap flags when runtimeIssuanceConfigMap is set
+    template: deployment.yaml
+    set:
+      app.runtimeIssuanceConfigMap: my-runtime-config
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --runtime-issuance-config-map-name=my-runtime-config
+
+  - it: should use release namespace for runtime configmap namespace flag
+    template: deployment.yaml
+    set:
+      app.runtimeIssuanceConfigMap: my-runtime-config
+    release:
+      namespace: cert-manager
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --runtime-issuance-config-map-namespace=cert-manager

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -115,7 +115,7 @@
     },
     "helm-values.app.approver.autoApproveNonSPIFFE": {
       "default": false,
-      "description": "When enabled, the approver will approve all CertificateRequests that do not target the configured SPIFFE issuer. This allows csi-driver-spiffe to act as a drop-in replacement for cert-manager's default approval controller, removing the need for approver-policy in simple deployments.\n\nWARNING: Enabling this grants the approver authority to approve all. CertificateRequests cluster-wide that do not target the SPIFFE issuer.",
+      "description": "When enabled, the approver will approve all CertificateRequests that do not target the configured SPIFFE issuer. This allows csi-driver-spiffe to act as a drop-in replacement for cert-manager's default approval controller, removing the need for approver-policy in simple deployments.\n\nWARNING: Enabling this grants the approver authority to approve all CertificateRequests cluster-wide that do not target the SPIFFE issuer.",
       "type": "boolean"
     },
     "helm-values.app.approver.metrics": {

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -92,6 +92,9 @@
     "helm-values.app.approver": {
       "additionalProperties": false,
       "properties": {
+        "autoApproveNonSpiffe": {
+          "$ref": "#/$defs/helm-values.app.approver.autoApproveNonSpiffe"
+        },
         "metrics": {
           "$ref": "#/$defs/helm-values.app.approver.metrics"
         },
@@ -109,6 +112,11 @@
         }
       },
       "type": "object"
+    },
+    "helm-values.app.approver.autoApproveNonSpiffe": {
+      "default": false,
+      "description": "When enabled, the approver will approve all CertificateRequests that do not target the configured SPIFFE issuer. This allows csi-driver-spiffe to act as a drop-in replacement for cert-manager's default approval controller, removing the need for approver-policy in simple deployments.\n\nWARNING: Enabling this grants the approver authority to approve all. CertificateRequests cluster-wide that do not target the SPIFFE issuer. Only enable if cert-manager's built-in auto-approver has been disabled.",
+      "type": "boolean"
     },
     "helm-values.app.approver.metrics": {
       "additionalProperties": false,

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -92,8 +92,8 @@
     "helm-values.app.approver": {
       "additionalProperties": false,
       "properties": {
-        "autoApproveNonSpiffe": {
-          "$ref": "#/$defs/helm-values.app.approver.autoApproveNonSpiffe"
+        "autoApproveNonSPIFFE": {
+          "$ref": "#/$defs/helm-values.app.approver.autoApproveNonSPIFFE"
         },
         "metrics": {
           "$ref": "#/$defs/helm-values.app.approver.metrics"
@@ -113,9 +113,9 @@
       },
       "type": "object"
     },
-    "helm-values.app.approver.autoApproveNonSpiffe": {
+    "helm-values.app.approver.autoApproveNonSPIFFE": {
       "default": false,
-      "description": "When enabled, the approver will approve all CertificateRequests that do not target the configured SPIFFE issuer. This allows csi-driver-spiffe to act as a drop-in replacement for cert-manager's default approval controller, removing the need for approver-policy in simple deployments.\n\nWARNING: Enabling this grants the approver authority to approve all. CertificateRequests cluster-wide that do not target the SPIFFE issuer. Only enable if cert-manager's built-in auto-approver has been disabled.",
+      "description": "When enabled, the approver will approve all CertificateRequests that do not target the configured SPIFFE issuer. This allows csi-driver-spiffe to act as a drop-in replacement for cert-manager's default approval controller, removing the need for approver-policy in simple deployments.\n\nWARNING: Enabling this grants the approver authority to approve all. CertificateRequests cluster-wide that do not target the SPIFFE issuer.",
       "type": "boolean"
     },
     "helm-values.app.approver.metrics": {

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -306,8 +306,8 @@ app:
     # act as a drop-in replacement for cert-manager's default approval
     # controller, removing the need for approver-policy in simple deployments.
     #
-    # WARNING: Enabling this grants the approver authority to approve all
-    # CertificateRequests cluster-wide that do not target the SPIFFE issuer.
+    # WARNING: Enabling this grants the approver authority to approve
+    # all CertificateRequests cluster-wide that do not target the SPIFFE issuer.
     autoApproveNonSPIFFE: false
 
     readinessProbe:

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -308,8 +308,7 @@ app:
     #
     # WARNING: Enabling this grants the approver authority to approve all
     # CertificateRequests cluster-wide that do not target the SPIFFE issuer.
-    # Only enable if cert-manager's built-in auto-approver has been disabled.
-    autoApproveNonSpiffe: false
+    autoApproveNonSPIFFE: false
 
     readinessProbe:
       # Container port to expose csi-driver-spiffe-approver HTTP readiness

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -301,6 +301,16 @@ app:
     # Defaults to empty which allows approval for all signers
     signerName: ""
 
+    # When enabled, the approver will approve all CertificateRequests that do
+    # not target the configured SPIFFE issuer. This allows csi-driver-spiffe to
+    # act as a drop-in replacement for cert-manager's default approval
+    # controller, removing the need for approver-policy in simple deployments.
+    #
+    # WARNING: Enabling this grants the approver authority to approve all
+    # CertificateRequests cluster-wide that do not target the SPIFFE issuer.
+    # Only enable if cert-manager's built-in auto-approver has been disabled.
+    autoApproveNonSpiffe: false
+
     readinessProbe:
       # Container port to expose csi-driver-spiffe-approver HTTP readiness
       # probe on default network interface.

--- a/internal/approver/app/app.go
+++ b/internal/approver/app/app.go
@@ -21,17 +21,20 @@ import (
 	"fmt"
 
 	"github.com/cert-manager/cert-manager/pkg/api"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/scale/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/cert-manager/csi-driver-spiffe/internal/approver/app/options"
 	"github.com/cert-manager/csi-driver-spiffe/internal/approver/controller"
 	"github.com/cert-manager/csi-driver-spiffe/internal/approver/evaluator"
+	"github.com/cert-manager/csi-driver-spiffe/internal/csi/runtimeconfig"
 )
 
 const (
@@ -58,6 +61,34 @@ func NewCommand(ctx context.Context) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := opts.Logr.WithName("main")
+
+			// Store the logger in the context so that packages using
+			// logr.FromContext can retrieve it.
+			ctx = logr.NewContext(ctx, opts.Logr)
+
+			var k8sClient client.WithWatch
+			if opts.CertManager.IssuanceConfigMapName != "" {
+				var err error
+				k8sClient, err = client.NewWithWatch(opts.RestConfig, client.Options{})
+				if err != nil {
+					return fmt.Errorf("failed to build kubernetes watcher client: %w", err)
+				}
+			}
+
+			rtConfig, err := runtimeconfig.New(ctx, k8sClient, runtimeconfig.Options{
+				StaticConfig: runtimeconfig.Config{IssuerRef: opts.CertManager.IssuerRef},
+				DynamicConfig: runtimeconfig.DynamicConfig{
+					ConfigMapName:      opts.CertManager.IssuanceConfigMapName,
+					ConfigMapNamespace: opts.CertManager.IssuanceConfigMapNamespace,
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			if opts.CertManager.AutoApproveNonSpiffe {
+				log.Info("auto-approval of non-SPIFFE CertificateRequests enabled: this approver will approve all CertificateRequests not targeting the configured SPIFFE issuer")
+			}
 
 			mgr, err := ctrl.NewManager(opts.RestConfig, ctrl.Options{
 				Scheme:                        intscheme,
@@ -88,8 +119,10 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			})
 
 			if err := controller.AddApprover(ctx, opts.Logr, controller.Options{
-				Evaluator: evaluator,
-				Manager:   mgr,
+				Evaluator:            evaluator,
+				Manager:              mgr,
+				RuntimeConfig:        rtConfig,
+				AutoApproveNonSpiffe: opts.CertManager.AutoApproveNonSpiffe,
 			}); err != nil {
 				return fmt.Errorf("failed to register approver controller: %w", err)
 			}

--- a/internal/approver/app/app.go
+++ b/internal/approver/app/app.go
@@ -86,7 +86,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if opts.CertManager.AutoApproveNonSpiffe {
+			if opts.CertManager.AutoApproveNonSPIFFE {
 				log.Info("auto-approval of non-SPIFFE CertificateRequests enabled: this approver will approve all CertificateRequests not targeting the configured SPIFFE issuer")
 			}
 
@@ -122,7 +122,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				Evaluator:            evaluator,
 				Manager:              mgr,
 				RuntimeConfig:        rtConfig,
-				AutoApproveNonSpiffe: opts.CertManager.AutoApproveNonSpiffe,
+				AutoApproveNonSPIFFE: opts.CertManager.AutoApproveNonSPIFFE,
 			}); err != nil {
 				return fmt.Errorf("failed to register approver controller: %w", err)
 			}

--- a/internal/approver/app/options/options.go
+++ b/internal/approver/app/options/options.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/csi-driver-spiffe/internal/flags"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -56,6 +57,12 @@ type OptionsController struct {
 
 // OptionsCertManager are options specific to cert-manager and the evaluator.
 type OptionsCertManager struct {
+	// IssuanceConfigMapName is the name of a ConfigMap to watch for configuration options. The ConfigMap is expected to be in the same namespace as the csi-driver-spiffe pod.
+	IssuanceConfigMapName string
+
+	// IssuanceConfigMapNamespace is the namespace where the runtime configuration ConfigMap is located
+	IssuanceConfigMapNamespace string
+
 	// TrustDomain is the Trust Domain the evaluator will enforce requests request for.
 	TrustDomain string
 
@@ -73,6 +80,13 @@ type OptionsCertManager struct {
 	// ServiceAccount (e.g. "system:serviceaccount:cert-manager:spiffe.csi.cert-manager.io").
 	// Only used when UseOwnServiceAccount is true.
 	DriverServiceAccount string
+
+	// IssuerRef is the IssuerRef used when creating CertificateRequests.
+	IssuerRef cmmeta.IssuerReference
+
+	// AutoApproveNonSpiffe enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
+	// csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.
+	AutoApproveNonSpiffe bool
 }
 
 func New() *Options {
@@ -84,6 +98,12 @@ func New() *Options {
 }
 
 func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.CertManager.IssuanceConfigMapName, "runtime-issuance-config-map-name", "",
+		"Name of a ConfigMap to watch at runtime for issuer details. If such a ConfigMap is found, overrides issuer-name, issuer-kind and issuer-group")
+
+	fs.StringVar(&o.CertManager.IssuanceConfigMapNamespace, "runtime-issuance-config-map-namespace", "",
+		"Namespace for ConfigMap to be watched at runtime for issuer details")
+
 	fs.StringVar(&o.CertManager.TrustDomain, "trust-domain", "cluster.local",
 		"The trust domain this approver ensures is present on requests.")
 
@@ -100,27 +120,17 @@ func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
 			"(e.g. \"system:serviceaccount:cert-manager:spiffe.csi.cert-manager.io\"). "+
 			"Required when --use-own-service-account is true.")
 
-	// allow issuer-* args to still be passed to avoid a backwards incompatible change
-	var dummyIssuerRefName, dummyIssuerRefKind, dummyIssuerRefGroup string
+	fs.StringVar(&o.CertManager.IssuerRef.Name, "issuer-name", "my-spiffe-ca",
+		"Name of the issuer that CertificateRequests will be created for.")
 
-	fs.StringVar(&dummyIssuerRefName, "issuer-name", "", "Deprecated; value is ignored")
-	fs.StringVar(&dummyIssuerRefKind, "issuer-kind", "", "Deprecated; value is ignored")
-	fs.StringVar(&dummyIssuerRefGroup, "issuer-group", "", "Deprecated; value is ignored")
+	fs.StringVar(&o.CertManager.IssuerRef.Kind, "issuer-kind", "ClusterIssuer",
+		"Kind of the issuer that CertificateRequests will be created for.")
 
-	err := fs.MarkDeprecated("issuer-name", "issuer-name is deprecated and will be ignored")
-	if err != nil {
-		panic("failed to mark issuer-name flag as deprecated; this is an internal programming error")
-	}
+	fs.StringVar(&o.CertManager.IssuerRef.Group, "issuer-group", "cert-manager.io",
+		"Group of the issuer that CertificateRequests will be created for.")
 
-	err = fs.MarkDeprecated("issuer-kind", "issuer-kind is deprecated and will be ignored")
-	if err != nil {
-		panic("failed to mark issuer-kind flag as deprecated; this is an internal programming error")
-	}
-
-	err = fs.MarkDeprecated("issuer-group", "issuer-group is deprecated and will be ignored")
-	if err != nil {
-		panic("failed to mark issuer-group flag as deprecated; this is an internal programming error")
-	}
+	fs.BoolVar(&o.CertManager.AutoApproveNonSpiffe, "auto-approve-non-spiffe", false,
+		"Enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.")
 }
 
 func (o *Options) addControllerFlags(fs *pflag.FlagSet) {

--- a/internal/approver/app/options/options.go
+++ b/internal/approver/app/options/options.go
@@ -99,7 +99,7 @@ func New() *Options {
 
 func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.CertManager.IssuanceConfigMapName, "runtime-issuance-config-map-name", "",
-		"Name of a ConfigMap to watch at runtime for issuer details. If such a ConfigMap is found, overrides issuer-name, issuer-kind and issuer-group")
+		"Name of a ConfigMap to watch at runtime for issuer details. If such a ConfigMap is found, it overrides issuer-name, issuer-kind and issuer-group")
 
 	fs.StringVar(&o.CertManager.IssuanceConfigMapNamespace, "runtime-issuance-config-map-namespace", "",
 		"Namespace for ConfigMap to be watched at runtime for issuer details")
@@ -121,13 +121,13 @@ func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
 			"Required when --use-own-service-account is true.")
 
 	fs.StringVar(&o.CertManager.IssuerRef.Name, "issuer-name", "my-spiffe-ca",
-		"Name of the issuer that CertificateRequests will be created for.")
+		"Name of the issuer for which CertificateRequests will be created.")
 
 	fs.StringVar(&o.CertManager.IssuerRef.Kind, "issuer-kind", "ClusterIssuer",
-		"Kind of the issuer that CertificateRequests will be created for.")
+		"Kind of the issuer for which CertificateRequests will be created.")
 
 	fs.StringVar(&o.CertManager.IssuerRef.Group, "issuer-group", "cert-manager.io",
-		"Group of the issuer that CertificateRequests will be created for.")
+		"Group of the issuer for which CertificateRequests will be created.")
 
 	fs.BoolVar(&o.CertManager.AutoApproveNonSPIFFE, "auto-approve-non-spiffe", false,
 		"Enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.")

--- a/internal/approver/app/options/options.go
+++ b/internal/approver/app/options/options.go
@@ -84,9 +84,9 @@ type OptionsCertManager struct {
 	// IssuerRef is the IssuerRef used when creating CertificateRequests.
 	IssuerRef cmmeta.IssuerReference
 
-	// AutoApproveNonSpiffe enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
+	// AutoApproveNonSPIFFE enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
 	// csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.
-	AutoApproveNonSpiffe bool
+	AutoApproveNonSPIFFE bool
 }
 
 func New() *Options {
@@ -129,7 +129,7 @@ func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.CertManager.IssuerRef.Group, "issuer-group", "cert-manager.io",
 		"Group of the issuer that CertificateRequests will be created for.")
 
-	fs.BoolVar(&o.CertManager.AutoApproveNonSpiffe, "auto-approve-non-spiffe", false,
+	fs.BoolVar(&o.CertManager.AutoApproveNonSPIFFE, "auto-approve-non-spiffe", false,
 		"Enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.")
 }
 

--- a/internal/approver/app/options/options.go
+++ b/internal/approver/app/options/options.go
@@ -19,9 +19,9 @@ package options
 import (
 	"time"
 
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/spf13/pflag"
 
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/csi-driver-spiffe/internal/flags"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/internal/approver/controller/controller.go
+++ b/internal/approver/controller/controller.go
@@ -23,6 +23,7 @@ import (
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	utilpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,9 +49,9 @@ type Options struct {
 	// issuer reference to use when creating CertificateRequests.
 	RuntimeConfig runtimeconfig.Interface
 
-	// AutoApproveNonSpiffe enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
+	// AutoApproveNonSPIFFE enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
 	// csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.
-	AutoApproveNonSpiffe bool
+	AutoApproveNonSPIFFE bool
 }
 
 // approver watches for CertificateRequests which have been created by the
@@ -74,9 +75,9 @@ type approver struct {
 	// issuer reference to use when creating CertificateRequests.
 	runtimeConfig runtimeconfig.Interface
 
-	// autoApproveNonSpiffe enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
+	// autoApproveNonSPIFFE enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
 	// csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.
-	autoApproveNonSpiffe bool
+	autoApproveNonSPIFFE bool
 }
 
 // AddApprover will register the approver controller.
@@ -87,7 +88,7 @@ func AddApprover(ctx context.Context, log logr.Logger, opts Options) error {
 		lister:               opts.Manager.GetCache(),
 		evaluator:            opts.Evaluator,
 		runtimeConfig:        opts.RuntimeConfig,
-		autoApproveNonSpiffe: opts.AutoApproveNonSpiffe,
+		autoApproveNonSPIFFE: opts.AutoApproveNonSPIFFE,
 	}
 
 	return ctrl.NewControllerManagedBy(opts.Manager).
@@ -120,7 +121,7 @@ func AddApprover(ctx context.Context, log logr.Logger, opts Options) error {
 
 			// When auto-approval is enabled, also process annotation-absent requests
 			// so they can be approved or denied based on their issuerRef.
-			return annotationExists || a.autoApproveNonSpiffe
+			return annotationExists || a.autoApproveNonSPIFFE
 		})).
 		Complete(a)
 }
@@ -148,6 +149,18 @@ func (a *approver) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result
 		log.Info("approving request")
 		apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Approved request")
 		return ctrl.Result{}, a.client.Status().Update(ctx, &cr)
+	}
+
+	// Deny unannotated requests that contain SPIFFE URI SANs to prevent
+	// impersonating a SPIFFE identity via a non-SPIFFE issuer.
+	if csr, err := utilpki.DecodeX509CertificateRequestBytes(cr.Spec.Request); err == nil {
+		for _, uri := range csr.URIs {
+			if uri.Scheme == "spiffe" {
+				log.Info("denying request")
+				apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Denied request: non-SPIFFE certificate request contains SPIFFE URI SAN")
+				return ctrl.Result{}, a.client.Status().Update(ctx, &cr)
+			}
+		}
 	}
 
 	// Deny unannotated requests that target the SPIFFE issuer to prevent

--- a/internal/approver/controller/controller.go
+++ b/internal/approver/controller/controller.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cert-manager/csi-driver-spiffe/internal/annotations"
 	"github.com/cert-manager/csi-driver-spiffe/internal/approver/evaluator"
+	"github.com/cert-manager/csi-driver-spiffe/internal/csi/runtimeconfig"
 )
 
 type Options struct {
@@ -42,6 +43,14 @@ type Options struct {
 	// Manager is a controller-runtime Manager that the Approver controller will
 	// be registered against.
 	Manager manager.Manager
+
+	// RuntimeConfig provides the current runtime configuration, including the
+	// issuer reference to use when creating CertificateRequests.
+	RuntimeConfig runtimeconfig.Interface
+
+	// AutoApproveNonSpiffe enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
+	// csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.
+	AutoApproveNonSpiffe bool
 }
 
 // approver watches for CertificateRequests which have been created by the
@@ -60,15 +69,25 @@ type approver struct {
 	// evaluator evaluates matched CertificateRequests for whether they should be
 	// approved or denied.
 	evaluator evaluator.Interface
+
+	// runtimeConfig provides the current runtime configuration, including the
+	// issuer reference to use when creating CertificateRequests.
+	runtimeConfig runtimeconfig.Interface
+
+	// autoApproveNonSpiffe enables the auto approval of non csi-driver-spiffe CertificateRequest resources. This allows
+	// csi-driver-spiffe to act as a drop in replacement for the cert-manager approval controller.
+	autoApproveNonSpiffe bool
 }
 
 // AddApprover will register the approver controller.
 func AddApprover(ctx context.Context, log logr.Logger, opts Options) error {
 	a := &approver{
-		log:       log.WithName("controller"),
-		client:    opts.Manager.GetClient(),
-		lister:    opts.Manager.GetCache(),
-		evaluator: opts.Evaluator,
+		log:                  log.WithName("controller"),
+		client:               opts.Manager.GetClient(),
+		lister:               opts.Manager.GetCache(),
+		evaluator:            opts.Evaluator,
+		runtimeConfig:        opts.RuntimeConfig,
+		autoApproveNonSpiffe: opts.AutoApproveNonSpiffe,
 	}
 
 	return ctrl.NewControllerManagedBy(opts.Manager).
@@ -98,7 +117,10 @@ func AddApprover(ctx context.Context, log logr.Logger, opts Options) error {
 			// We expect that all csi-driver-spiffe certificates will have the identity
 			// annotation, so check for its existence as a final filter
 			_, annotationExists := req.ObjectMeta.Annotations[annotations.SPIFFEIdentityAnnnotationKey]
-			return annotationExists
+
+			// When auto-approval is enabled, also process annotation-absent requests
+			// so they can be approved or denied based on their issuerRef.
+			return annotationExists || a.autoApproveNonSpiffe
 		})).
 		Complete(a)
 }
@@ -115,12 +137,28 @@ func (a *approver) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err := a.evaluator.Evaluate(&cr); err != nil {
-		log.Error(err, "denying request")
-		apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Denied request: "+err.Error())
+	// If the annotation is set we use the normal evaluation flow
+	if _, annotationExists := cr.Annotations[annotations.SPIFFEIdentityAnnnotationKey]; annotationExists {
+		if err := a.evaluator.Evaluate(&cr); err != nil {
+			log.Error(err, "denying request")
+			apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Denied request: "+err.Error())
+			return ctrl.Result{}, a.client.Status().Update(ctx, &cr)
+		}
+
+		log.Info("approving request")
+		apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Approved request")
 		return ctrl.Result{}, a.client.Status().Update(ctx, &cr)
 	}
 
+	// Deny unannotated requests that target the SPIFFE issuer to prevent
+	// obtaining a SPIFFE certificate outside of the normal validation path.
+	if cr.Spec.IssuerRef == a.runtimeConfig.Config().IssuerRef {
+		log.Info("denying request")
+		apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Denied request: non-SPIFFE certificate targeting configured SPIFFE issuer")
+		return ctrl.Result{}, a.client.Status().Update(ctx, &cr)
+	}
+
+	// Request is not for the spiffe issuer, auto approve
 	log.Info("approving request")
 	apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Approved request")
 	return ctrl.Result{}, a.client.Status().Update(ctx, &cr)

--- a/internal/approver/controller/controller.go
+++ b/internal/approver/controller/controller.go
@@ -156,7 +156,7 @@ func (a *approver) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result
 	if csr, err := utilpki.DecodeX509CertificateRequestBytes(cr.Spec.Request); err == nil {
 		for _, uri := range csr.URIs {
 			if uri.Scheme == "spiffe" {
-				log.Info("denying request")
+				log.Info("denying request: non-SPIFFE certificate request contains SPIFFE URI SAN")
 				apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Denied request: non-SPIFFE certificate request contains SPIFFE URI SAN")
 				return ctrl.Result{}, a.client.Status().Update(ctx, &cr)
 			}
@@ -166,7 +166,7 @@ func (a *approver) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result
 	// Deny unannotated requests that target the SPIFFE issuer to prevent
 	// obtaining a SPIFFE certificate outside of the normal validation path.
 	if cr.Spec.IssuerRef == a.runtimeConfig.Config().IssuerRef {
-		log.Info("denying request")
+		log.Info("denying request: non-SPIFFE certificate targeting configured SPIFFE issuer")
 		apiutil.SetCertificateRequestCondition(&cr, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "spiffe.csi.cert-manager.io", "Denied request: non-SPIFFE certificate targeting configured SPIFFE issuer")
 		return ctrl.Result{}, a.client.Status().Update(ctx, &cr)
 	}

--- a/internal/approver/controller/controller_test.go
+++ b/internal/approver/controller/controller_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"bytes"
-	"context"
 	"encoding/pem"
 	"errors"
 	"testing"
@@ -66,7 +65,7 @@ func Test_Reconcile(t *testing.T) {
 		Kind:  "ClusterIssuer",
 		Group: "cert-manager.io",
 	}
-	spiffeRuntimeConfig := runtimeconfig.NewMemory(context.Background(),
+	spiffeRuntimeConfig := runtimeconfig.NewMemory(t.Context(),
 		runtimeconfig.Config{IssuerRef: spiffeIssuerRef}, nil)
 
 	pk, err := utilpki.GenerateECPrivateKey(utilpki.ECCurve521)

--- a/internal/approver/controller/controller_test.go
+++ b/internal/approver/controller/controller_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
+	"encoding/pem"
 	"errors"
 	"testing"
 	"time"
@@ -26,6 +28,7 @@ import (
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	utilpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -66,11 +69,25 @@ func Test_Reconcile(t *testing.T) {
 	spiffeRuntimeConfig := runtimeconfig.NewMemory(context.Background(),
 		runtimeconfig.Config{IssuerRef: spiffeIssuerRef}, nil)
 
+	pk, err := utilpki.GenerateECPrivateKey(utilpki.ECCurve521)
+	assert.NoError(t, err)
+	spiffeCSR, err := utilpki.GenerateCSR(&cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{
+			PrivateKey: &cmapi.CertificatePrivateKey{Algorithm: cmapi.ECDSAKeyAlgorithm},
+			URIs:       []string{"spiffe://cluster.local/ns/test-ns/sa/test-sa"},
+		},
+	})
+	assert.NoError(t, err)
+	spiffeCSRDER, err := utilpki.EncodeCSR(spiffeCSR, pk)
+	assert.NoError(t, err)
+	spiffeCSRPEM := bytes.NewBuffer([]byte{})
+	assert.NoError(t, pem.Encode(spiffeCSRPEM, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: spiffeCSRDER}))
+
 	tests := map[string]struct {
 		existingCRObjects    []client.Object
 		evaluator            evaluator.Interface
 		runtimeConfig        runtimeconfig.Interface
-		autoApproveNonSpiffe bool
+		autoApproveNonSPIFFE bool
 		expResult            ctrl.Result
 		expError             bool
 		expObjects           []client.Object
@@ -150,7 +167,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			evaluator:            fake.New(),
 			runtimeConfig:        spiffeRuntimeConfig,
-			autoApproveNonSpiffe: true,
+			autoApproveNonSPIFFE: true,
 			expResult:            ctrl.Result{},
 			expError:             false,
 			expObjects: []client.Object{
@@ -181,7 +198,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			evaluator:            fake.New(),
 			runtimeConfig:        spiffeRuntimeConfig,
-			autoApproveNonSpiffe: true,
+			autoApproveNonSPIFFE: true,
 			expResult:            ctrl.Result{},
 			expError:             false,
 			expObjects: []client.Object{
@@ -195,6 +212,43 @@ func Test_Reconcile(t *testing.T) {
 								Status:             cmmeta.ConditionTrue,
 								Reason:             "spiffe.csi.cert-manager.io",
 								Message:            "Denied request: non-SPIFFE certificate targeting configured SPIFFE issuer",
+								LastTransitionTime: fixedmetatime,
+							},
+						},
+					},
+				},
+			},
+		},
+		"auto-approve: unannotated request with SPIFFE URI SAN is Denied": {
+			existingCRObjects: []client.Object{
+				&cmapi.CertificateRequest{
+					TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequest", APIVersion: "cert-manager.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "10"},
+					Spec: cmapi.CertificateRequestSpec{
+						IssuerRef: otherIssuerRef,
+						Request:   spiffeCSRPEM.Bytes(),
+					},
+				},
+			},
+			evaluator:            fake.New(),
+			runtimeConfig:        spiffeRuntimeConfig,
+			autoApproveNonSPIFFE: true,
+			expResult:            ctrl.Result{},
+			expError:             false,
+			expObjects: []client.Object{
+				&cmapi.CertificateRequest{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "11"},
+					Spec: cmapi.CertificateRequestSpec{
+						IssuerRef: otherIssuerRef,
+						Request:   spiffeCSRPEM.Bytes(),
+					},
+					Status: cmapi.CertificateRequestStatus{
+						Conditions: []cmapi.CertificateRequestCondition{
+							{
+								Type:               cmapi.CertificateRequestConditionDenied,
+								Status:             cmmeta.ConditionTrue,
+								Reason:             "spiffe.csi.cert-manager.io",
+								Message:            "Denied request: non-SPIFFE certificate request contains SPIFFE URI SAN",
 								LastTransitionTime: fixedmetatime,
 							},
 						},
@@ -220,7 +274,7 @@ func Test_Reconcile(t *testing.T) {
 				log:                  ktesting.NewLogger(t, ktesting.DefaultConfig),
 				evaluator:            test.evaluator,
 				runtimeConfig:        test.runtimeConfig,
-				autoApproveNonSpiffe: test.autoApproveNonSpiffe,
+				autoApproveNonSPIFFE: test.autoApproveNonSPIFFE,
 			}
 
 			result, err := a.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-cr"}})

--- a/internal/approver/controller/controller_test.go
+++ b/internal/approver/controller/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/cert-manager/csi-driver-spiffe/internal/approver/evaluator"
 	"github.com/cert-manager/csi-driver-spiffe/internal/approver/evaluator/fake"
+	"github.com/cert-manager/csi-driver-spiffe/internal/csi/runtimeconfig"
 )
 
 func Test_Reconcile(t *testing.T) {
@@ -47,12 +49,31 @@ func Test_Reconcile(t *testing.T) {
 		fixedclock    = fakeclock.NewFakeClock(fixedTime)
 	)
 
+	spiffeAnnotations := map[string]string{
+		"spiffe.csi.cert-manager.io/identity": "spiffe://cluster.local/ns/test-ns/sa/test-sa",
+	}
+
+	spiffeIssuerRef := cmmeta.IssuerReference{
+		Name:  "spiffe-ca",
+		Kind:  "ClusterIssuer",
+		Group: "cert-manager.io",
+	}
+	otherIssuerRef := cmmeta.IssuerReference{
+		Name:  "other-ca",
+		Kind:  "ClusterIssuer",
+		Group: "cert-manager.io",
+	}
+	spiffeRuntimeConfig := runtimeconfig.NewMemory(context.Background(),
+		runtimeconfig.Config{IssuerRef: spiffeIssuerRef}, nil)
+
 	tests := map[string]struct {
-		existingCRObjects []client.Object
-		evaluator         evaluator.Interface
-		expResult         ctrl.Result
-		expError          bool
-		expObjects        []client.Object
+		existingCRObjects    []client.Object
+		evaluator            evaluator.Interface
+		runtimeConfig        runtimeconfig.Interface
+		autoApproveNonSpiffe bool
+		expResult            ctrl.Result
+		expError             bool
+		expObjects           []client.Object
 	}{
 		"if CertificateRequest doesn't exist, ignore": {
 			existingCRObjects: []client.Object{},
@@ -65,7 +86,7 @@ func Test_Reconcile(t *testing.T) {
 			existingCRObjects: []client.Object{
 				&cmapi.CertificateRequest{
 					TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequest", APIVersion: "cert-manager.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "10"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "10", Annotations: spiffeAnnotations},
 				},
 			},
 			expResult: ctrl.Result{},
@@ -75,7 +96,7 @@ func Test_Reconcile(t *testing.T) {
 			expError: false,
 			expObjects: []client.Object{
 				&cmapi.CertificateRequest{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "11"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "11", Annotations: spiffeAnnotations},
 					Status: cmapi.CertificateRequestStatus{
 						Conditions: []cmapi.CertificateRequestCondition{
 							{
@@ -94,7 +115,7 @@ func Test_Reconcile(t *testing.T) {
 			existingCRObjects: []client.Object{
 				&cmapi.CertificateRequest{
 					TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequest", APIVersion: "cert-manager.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "10"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "10", Annotations: spiffeAnnotations},
 				},
 			},
 			expResult: ctrl.Result{},
@@ -104,7 +125,7 @@ func Test_Reconcile(t *testing.T) {
 			expError: false,
 			expObjects: []client.Object{
 				&cmapi.CertificateRequest{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "11"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "11", Annotations: spiffeAnnotations},
 					Status: cmapi.CertificateRequestStatus{
 						Conditions: []cmapi.CertificateRequestCondition{
 							{
@@ -112,6 +133,68 @@ func Test_Reconcile(t *testing.T) {
 								Status:             cmmeta.ConditionTrue,
 								Reason:             "spiffe.csi.cert-manager.io",
 								Message:            "Approved request",
+								LastTransitionTime: fixedmetatime,
+							},
+						},
+					},
+				},
+			},
+		},
+		"auto-approve: unannotated request targeting non-SPIFFE issuer is Approved": {
+			existingCRObjects: []client.Object{
+				&cmapi.CertificateRequest{
+					TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequest", APIVersion: "cert-manager.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "10"},
+					Spec:       cmapi.CertificateRequestSpec{IssuerRef: otherIssuerRef},
+				},
+			},
+			evaluator:            fake.New(),
+			runtimeConfig:        spiffeRuntimeConfig,
+			autoApproveNonSpiffe: true,
+			expResult:            ctrl.Result{},
+			expError:             false,
+			expObjects: []client.Object{
+				&cmapi.CertificateRequest{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "11"},
+					Spec:       cmapi.CertificateRequestSpec{IssuerRef: otherIssuerRef},
+					Status: cmapi.CertificateRequestStatus{
+						Conditions: []cmapi.CertificateRequestCondition{
+							{
+								Type:               cmapi.CertificateRequestConditionApproved,
+								Status:             cmmeta.ConditionTrue,
+								Reason:             "spiffe.csi.cert-manager.io",
+								Message:            "Approved request",
+								LastTransitionTime: fixedmetatime,
+							},
+						},
+					},
+				},
+			},
+		},
+		"auto-approve: unannotated request targeting SPIFFE issuer is Denied": {
+			existingCRObjects: []client.Object{
+				&cmapi.CertificateRequest{
+					TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequest", APIVersion: "cert-manager.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "10"},
+					Spec:       cmapi.CertificateRequestSpec{IssuerRef: spiffeIssuerRef},
+				},
+			},
+			evaluator:            fake.New(),
+			runtimeConfig:        spiffeRuntimeConfig,
+			autoApproveNonSpiffe: true,
+			expResult:            ctrl.Result{},
+			expError:             false,
+			expObjects: []client.Object{
+				&cmapi.CertificateRequest{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-cr", ResourceVersion: "11"},
+					Spec:       cmapi.CertificateRequestSpec{IssuerRef: spiffeIssuerRef},
+					Status: cmapi.CertificateRequestStatus{
+						Conditions: []cmapi.CertificateRequestCondition{
+							{
+								Type:               cmapi.CertificateRequestConditionDenied,
+								Status:             cmmeta.ConditionTrue,
+								Reason:             "spiffe.csi.cert-manager.io",
+								Message:            "Denied request: non-SPIFFE certificate targeting configured SPIFFE issuer",
 								LastTransitionTime: fixedmetatime,
 							},
 						},
@@ -132,10 +215,12 @@ func Test_Reconcile(t *testing.T) {
 				Build()
 
 			a := &approver{
-				client:    fakeclient,
-				lister:    fakeclient,
-				log:       ktesting.NewLogger(t, ktesting.DefaultConfig),
-				evaluator: test.evaluator,
+				client:               fakeclient,
+				lister:               fakeclient,
+				log:                  ktesting.NewLogger(t, ktesting.DefaultConfig),
+				evaluator:            test.evaluator,
+				runtimeConfig:        test.runtimeConfig,
+				autoApproveNonSpiffe: test.autoApproveNonSpiffe,
 			}
 
 			result, err := a.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-cr"}})

--- a/internal/csi/app/app.go
+++ b/internal/csi/app/app.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/app/options"
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/driver"
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/rootca"
+	"github.com/cert-manager/csi-driver-spiffe/internal/csi/runtimeconfig"
 	"github.com/cert-manager/csi-driver-spiffe/internal/version"
 )
 
@@ -61,6 +64,30 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				log.Info("propagating root CA bundle disabled")
 			}
 
+			// Store the logger in the context so that packages using
+			// logr.FromContext can retrieve it.
+			ctx = logr.NewContext(ctx, opts.Logr)
+
+			var k8sClient client.WithWatch
+			if opts.CertManager.IssuanceConfigMapName != "" {
+				var err error
+				k8sClient, err = client.NewWithWatch(opts.RestConfig, client.Options{})
+				if err != nil {
+					return fmt.Errorf("failed to build kubernetes watcher client: %w", err)
+				}
+			}
+
+			rtConfig, err := runtimeconfig.New(ctx, k8sClient, runtimeconfig.Options{
+				StaticConfig: runtimeconfig.Config{IssuerRef: opts.CertManager.IssuerRef},
+				DynamicConfig: runtimeconfig.DynamicConfig{
+					ConfigMapName:      opts.CertManager.IssuanceConfigMapName,
+					ConfigMapNamespace: opts.CertManager.IssuanceConfigMapNamespace,
+				},
+			})
+			if err != nil {
+				return err
+			}
+
 			driver, err := driver.New(ctx, opts.Logr, driver.Options{
 				DriverName: opts.DriverName,
 				NodeID:     opts.Driver.NodeID,
@@ -71,16 +98,13 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				TrustDomain:                   opts.CertManager.TrustDomain,
 				CertificateRequestAnnotations: opts.CertManager.CertificateRequestAnnotations,
 				CertificateRequestDuration:    opts.CertManager.CertificateRequestDuration,
-				IssuerRef:                     &opts.CertManager.IssuerRef,
-
-				IssuanceConfigMapName:      opts.CertManager.IssuanceConfigMapName,
-				IssuanceConfigMapNamespace: opts.CertManager.IssuanceConfigMapNamespace,
 
 				CertificateFileName: opts.Volume.CertificateFileName,
 				KeyFileName:         opts.Volume.KeyFileName,
 
 				CAFileName:           opts.Volume.CAFileName,
 				RootCAs:              rootCA,
+				RuntimeConfig:        rtConfig,
 				UseOwnServiceAccount: opts.Driver.UseOwnServiceAccount,
 			})
 			if err != nil {

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmversioned "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	"github.com/cert-manager/csi-lib/driver"
 	"github.com/cert-manager/csi-lib/manager"
@@ -40,15 +39,12 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/clock"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cert-manager/csi-driver-spiffe/internal/annotations"
 	"github.com/cert-manager/csi-driver-spiffe/internal/csi/rootca"
+	"github.com/cert-manager/csi-driver-spiffe/internal/csi/runtimeconfig"
 	"github.com/cert-manager/csi-driver-spiffe/internal/version"
 )
 
@@ -78,9 +74,6 @@ type Options struct {
 	// Defaults to 1 hour if empty.
 	CertificateRequestDuration time.Duration
 
-	// IssuerRef is the IssuerRef used when creating CertificateRequests.
-	IssuerRef *cmmeta.IssuerReference
-
 	// CertificateFileName is the name of the file that the signed certificate
 	// will be written to inside the Pod's volume.
 	// Default to `tls.crt` if empty.
@@ -105,11 +98,9 @@ type Options struct {
 	// file will be updated.
 	RootCAs rootca.Interface
 
-	// IssuanceConfigMapName is the name of the ConfigMap to watch for issuance configuration.
-	IssuanceConfigMapName string
-
-	// IssuanceConfigMapNamespace is the namespace of the ConfigMap to watch for issuance configuration
-	IssuanceConfigMapNamespace string
+	// RuntimeConfig provides the current runtime configuration, including the
+	// issuer reference to use when creating CertificateRequests.
+	RuntimeConfig runtimeconfig.Interface
 
 	// UseOwnServiceAccount, when true, causes the driver to create
 	// CertificateRequests using its own ServiceAccount credentials rather than
@@ -134,21 +125,6 @@ type Driver struct {
 	// created CertificateRequests.
 	certificateRequestDuration time.Duration
 
-	// activeIssuerRef is the issuerRef that will be set on all created CertificateRequests.
-	// Can be changed at runtime via runtime configuration (i.e. reading from a ConfigMap)
-	// Not to be confused with originalIssuerRef, which is an issuerRef optionally passed in
-	// via CLI args.
-	activeIssuerRef *cmmeta.IssuerReference
-
-	// originalIssuerRef is the issuerRef passed into the driver at startup. This will be used
-	// if no runtime configuration (ConfigMap configuration) is found, or if the ConfigMap for
-	// runtime configuration is deleted.
-	originalIssuerRef *cmmeta.IssuerReference
-
-	// activeIssuerRefMutex is used to control changes to the activeIssuerRef which can happen
-	// concurrently with a request to issue a new cert
-	activeIssuerRefMutex *sync.RWMutex
-
 	// certFileName, keyFileName, caFileName are the names used when writing file
 	// to volumes.
 	certFileName, keyFileName, caFileName string
@@ -156,6 +132,9 @@ type Driver struct {
 	// rootCAs provides the root CA certificates to write to file. No CA file is
 	// written if this is nil.
 	rootCAs rootca.Interface
+
+	// runtimeConfig provides the current runtime configuration.
+	runtimeConfig runtimeconfig.Interface
 
 	// driver is the csi-lib implementation of a cert-manager CSI driver.
 	driver *driver.Driver
@@ -166,17 +145,6 @@ type Driver struct {
 	// camanager is used to update all managed volumes with the current root CA
 	// certificates PEM.
 	camanager *camanager
-
-	// kubernetesClient is used to watch ConfigMaps for issuance configuration
-	kubernetesClient client.WithWatch
-
-	// issuanceConfigMapName is the name of a ConfigMap which will be
-	// watched for issuance configuration at runtime
-	issuanceConfigMapName string
-
-	// issuanceConfigMapNamespace is the name of a ConfigMap which will be
-	// watched for issuance configuration at runtime
-	issuanceConfigMapNamespace string
 }
 
 // New constructs a new Driver instance.
@@ -187,39 +155,18 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 		// don't exit, not a fatal error as sanitizeAnnotations will trim bad annotations
 	}
 
-	originalIssuerRef, err := handleOriginalIssuerRef(opts.IssuerRef)
-	if err != nil && err != errNoOriginalIssuer {
-		return nil, err
-	}
-
-	if originalIssuerRef == nil && (opts.IssuanceConfigMapName == "" || opts.IssuanceConfigMapNamespace == "") {
-		// if no install-time issuer was configured, runtime issuance details are not optional
-		return nil, fmt.Errorf("runtime issuance configuration is required if no issuer is provided at startup")
-	}
-
 	d := &Driver{
 		log:          log.WithName("csi"),
 		trustDomain:  opts.TrustDomain,
 		certFileName: opts.CertificateFileName,
 		keyFileName:  opts.KeyFileName,
 
-		// we check if we can set activeIssuerRef later
-		activeIssuerRef:   nil,
-		originalIssuerRef: originalIssuerRef,
-
-		activeIssuerRefMutex: &sync.RWMutex{},
-
 		rootCAs: opts.RootCAs,
 
 		certificateRequestDuration:    opts.CertificateRequestDuration,
 		certificateRequestAnnotations: sanitizedAnnotations,
 
-		issuanceConfigMapName:      opts.IssuanceConfigMapName,
-		issuanceConfigMapNamespace: opts.IssuanceConfigMapNamespace,
-	}
-
-	if d.originalIssuerRef != nil {
-		d.activeIssuerRef = d.originalIssuerRef
+		runtimeConfig: opts.RuntimeConfig,
 	}
 
 	if len(d.certFileName) == 0 {
@@ -264,12 +211,6 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 		clientForMeta = util.ClientForMetadataTokenRequestEmptyAud(opts.RestConfig)
 	}
 
-	k8sClient, err := client.NewWithWatch(opts.RestConfig, client.Options{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to build kubernetes watcher client: %w", err)
-	}
-
-	d.kubernetesClient = k8sClient
 
 	mngrLog := d.log.WithName("manager")
 	d.driver, err = driver.New(ctx, opts.Endpoint, d.log.WithName("driver"), driver.Options{
@@ -298,149 +239,6 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 	return d, nil
 }
 
-// watchRuntimeConfigurationSource should be called in a goroutine to watch a ConfigMap for runtime configuration
-func (d *Driver) watchRuntimeConfigurationSource(ctx context.Context) {
-	logger := d.log.WithName("runtime-config-watcher").WithValues("config-map-name", d.issuanceConfigMapName, "config-map-namespace", d.issuanceConfigMapNamespace)
-
-LOOP:
-	for {
-		logger.Info("Starting / restarting watcher for runtime configuration")
-		cmList := &corev1.ConfigMapList{}
-
-		// First create a watcher. This is in a labelled loop in case the watcher dies for some reason
-		// while we're running - in that case, we don't want to give up entirely on watching for runtime config
-		// but instead we want to recreate the watcher.
-
-		watcher, err := d.kubernetesClient.Watch(ctx, cmList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector("metadata.name", d.issuanceConfigMapName),
-			Namespace:     d.issuanceConfigMapNamespace,
-		})
-
-		if err != nil {
-			logger.Error(err, "Failed to create ConfigMap watcher; will retry in 5s")
-			time.Sleep(5 * time.Second)
-			continue
-		}
-
-		for {
-			// Now loop indefinitely until the main context cancels or we get an event to process.
-			// If the main context cancels, we break out of the outer loop and this function returns.
-			// If we get an event, we first check whether the channel closed. If so, we recreate the watcher by continuing
-			// the outer loop.
-			select {
-			case <-ctx.Done():
-				logger.Info("Received context cancellation, shutting down runtime configuration watcher")
-				watcher.Stop()
-				break LOOP
-
-			case event, open := <-watcher.ResultChan():
-				if !open {
-					logger.Info("Received closed channel from ConfigMap watcher, will recreate")
-					watcher.Stop()
-					continue LOOP
-				}
-
-				switch event.Type {
-				case watch.Deleted:
-					d.handleRuntimeConfigIssuerDeletion(logger)
-
-				case watch.Added:
-					err := d.handleRuntimeConfigIssuerChange(logger, event)
-					if err != nil {
-						logger.Error(err, "Failed to handle new runtime configuration for issuerRef")
-					}
-
-				case watch.Modified:
-					err := d.handleRuntimeConfigIssuerChange(logger, event)
-					if err != nil {
-						logger.Error(err, "Failed to handle runtime configuration issuerRef change")
-					}
-
-				case watch.Bookmark:
-					// Ignore
-
-				case watch.Error:
-					err, ok := event.Object.(error)
-					if !ok {
-						logger.Error(nil, "Got an error event when watching runtime configuration but unable to determine further information")
-					} else {
-						logger.Error(err, "Got an error event when watching runtime configuration")
-					}
-
-				default:
-					logger.Info("Got unknown event for runtime configuration ConfigMap; ignoring", "event-type", string(event.Type))
-				}
-			}
-		}
-	}
-
-	logger.Info("Stopped runtime configuration watcher")
-}
-
-const (
-	issuerNameKey  = "issuer-name"
-	issuerKindKey  = "issuer-kind"
-	issuerGroupKey = "issuer-group"
-)
-
-func (d *Driver) handleRuntimeConfigIssuerChange(logger logr.Logger, event watch.Event) error {
-	d.activeIssuerRefMutex.Lock()
-	defer d.activeIssuerRefMutex.Unlock()
-
-	cm, ok := event.Object.(*corev1.ConfigMap)
-	if !ok {
-		return fmt.Errorf("got unexpected type for runtime configuration source; this is likely a programming error")
-	}
-
-	issuerRef := &cmmeta.IssuerReference{}
-
-	var dataErrs []error
-	var exists bool
-
-	issuerRef.Name, exists = cm.Data[issuerNameKey]
-	if !exists || len(issuerRef.Name) == 0 {
-		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data: %s", issuerNameKey))
-	}
-
-	issuerRef.Kind, exists = cm.Data[issuerKindKey]
-	if !exists || len(issuerRef.Kind) == 0 {
-		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data: %s", issuerKindKey))
-	}
-
-	issuerRef.Group, exists = cm.Data[issuerGroupKey]
-	if !exists || len(issuerRef.Group) == 0 {
-		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data; %s", issuerGroupKey))
-	}
-
-	if len(dataErrs) > 0 {
-		return errors.Join(dataErrs...)
-	}
-
-	// we now have a full issuerRef
-	// TODO: check if the issuer exists by querying for the CRD?
-
-	d.activeIssuerRef = issuerRef
-
-	logger.Info("Changed active issuerRef in response to runtime configuration ConfigMap", "issuer-name", d.activeIssuerRef.Name, "issuer-kind", d.activeIssuerRef.Kind, "issuer-group", d.activeIssuerRef.Group)
-
-	return nil
-}
-
-func (d *Driver) handleRuntimeConfigIssuerDeletion(logger logr.Logger) {
-	d.activeIssuerRefMutex.Lock()
-	defer d.activeIssuerRefMutex.Unlock()
-
-	if d.originalIssuerRef == nil {
-		logger.Info("Runtime issuance configuration was deleted and no issuerRef was configured at install time; issuance will fail until runtime configuration is reinstated")
-		d.activeIssuerRef = nil
-		return
-	}
-
-	logger.Info("Runtime issuance configuration was deleted; issuance will revert to original issuerRef configured at install time")
-
-	d.activeIssuerRef = d.originalIssuerRef
-}
-
 // Run is a blocking func that runs the CSI driver.
 func (d *Driver) Run(ctx context.Context) error {
 	var wg sync.WaitGroup
@@ -454,12 +252,6 @@ func (d *Driver) Run(ctx context.Context) error {
 		updateRetryPeriod := time.Second * 5
 		d.camanager.run(ctx, updateRetryPeriod)
 	})
-
-	if d.hasRuntimeConfiguration() {
-		wg.Go(func() {
-			d.watchRuntimeConfigurationSource(ctx)
-		})
-	}
 
 	wg.Add(1)
 	var err error
@@ -492,10 +284,8 @@ var validSigningAlgs = []jose.SignatureAlgorithm{
 // generateRequest will generate a SPIFFE manager.CertificateRequestBundle
 // based upon the identity contained in the metadata service account token.
 func (d *Driver) generateRequest(meta metadata.Metadata) (*manager.CertificateRequestBundle, error) {
-	d.activeIssuerRefMutex.RLock()
-	defer d.activeIssuerRefMutex.RUnlock()
-
-	if d.activeIssuerRef == nil {
+	cfg := d.runtimeConfig.Config()
+	if cfg.IssuerRef.Name == "" {
 		return nil, fmt.Errorf("no issuerRef is currently active for csi-driver-spiffe; configure one using runtime configuration")
 	}
 
@@ -558,7 +348,7 @@ func (d *Driver) generateRequest(meta metadata.Metadata) (*manager.CertificateRe
 			cmapi.UsageServerAuth,
 			cmapi.UsageClientAuth,
 		},
-		IssuerRef:   *d.activeIssuerRef,
+		IssuerRef:   cfg.IssuerRef,
 		Annotations: crAnnotations,
 	}, nil
 }
@@ -607,12 +397,6 @@ func (d *Driver) writeKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 	return nil
 }
 
-// hasRuntimeConfiguration returns true if runtime configuration has been correctly
-// configured with a ConfigMap name and namespace, and false otherwise.
-func (d *Driver) hasRuntimeConfiguration() bool {
-	return d.issuanceConfigMapName != "" && d.issuanceConfigMapNamespace != ""
-}
-
 func sanitizeAnnotations(in map[string]string) (map[string]string, error) {
 	out := map[string]string{}
 
@@ -628,30 +412,4 @@ func sanitizeAnnotations(in map[string]string) (map[string]string, error) {
 	}
 
 	return out, errors.Join(errs...)
-}
-
-var errNoOriginalIssuer = fmt.Errorf("no original issuer was provided")
-
-func handleOriginalIssuerRef(in *cmmeta.IssuerReference) (*cmmeta.IssuerReference, error) {
-	if in == nil {
-		return nil, errNoOriginalIssuer
-	}
-
-	if in.Name == "" && in.Kind == "" && in.Group == "" {
-		return nil, errNoOriginalIssuer
-	}
-
-	if in.Name == "" {
-		return nil, fmt.Errorf("issuerRef.Name is a required field if any field is set for issuerRef")
-	}
-
-	if in.Kind == "" {
-		return nil, fmt.Errorf("issuerRef.Kind is a required field if any field is set for issuerRef")
-	}
-
-	if in.Group == "" {
-		return nil, fmt.Errorf("issuerRef.Group is a required field if any field is set for issuerRef")
-	}
-
-	return in, nil
 }

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -211,7 +211,6 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 		clientForMeta = util.ClientForMetadataTokenRequestEmptyAud(opts.RestConfig)
 	}
 
-
 	mngrLog := d.log.WithName("manager")
 	d.driver, err = driver.New(ctx, opts.Endpoint, d.log.WithName("driver"), driver.Options{
 		DriverName:    opts.DriverName,

--- a/internal/csi/runtimeconfig/configmap.go
+++ b/internal/csi/runtimeconfig/configmap.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	issuerNameKey  = "issuer-name"
+	issuerKindKey  = "issuer-kind"
+	issuerGroupKey = "issuer-group"
+)
+
+// configmap is an implementation of Interface that watches a Kubernetes
+// ConfigMap for runtime configuration and broadcasts a message when the
+// configuration changes.
+type configmap struct {
+	// log is the logger.
+	log logr.Logger
+
+	// k8sClient is used to watch the ConfigMap.
+	k8sClient client.WithWatch
+
+	// configMapName is the name of the ConfigMap to watch.
+	configMapName string
+
+	// configMapNamespace is the namespace of the ConfigMap to watch.
+	configMapNamespace string
+
+	// active is the currently active configuration.
+	active Config
+
+	// static is the fallback configuration used when the ConfigMap is absent.
+	static Config
+
+	// lock guards access to active.
+	lock sync.RWMutex
+}
+
+// NewConfigMap constructs a new configmap implementation of Interface. It sets
+// the active configuration to static initially and starts a goroutine to watch
+// the named ConfigMap. When the ConfigMap is added or modified the active
+// configuration is updated from the three keys issuer-name, issuer-kind, and
+// issuer-group. When the ConfigMap is deleted the active configuration reverts
+// to static. The logger is extracted from ctx via logr.FromContext.
+func NewConfigMap(ctx context.Context, k8sClient client.WithWatch, configMapName, configMapNamespace string, static Config) Interface {
+	log := logr.FromContextOrDiscard(ctx).
+		WithName("runtime-config-watcher").
+		WithValues("config-map-name", configMapName, "config-map-namespace", configMapNamespace)
+
+	c := &configmap{
+		log:                log,
+		k8sClient:          k8sClient,
+		configMapName:      configMapName,
+		configMapNamespace: configMapNamespace,
+		active:             static,
+		static:             static,
+	}
+
+	go c.start(ctx)
+
+	return c
+}
+
+// start watches the ConfigMap for changes and updates the active configuration.
+// It is intended to be run in a goroutine and retries on failure with a 5s
+// delay. It returns when ctx is cancelled.
+func (c *configmap) start(ctx context.Context) {
+LOOP:
+	for {
+		c.log.Info("Starting / restarting watcher for runtime configuration")
+		cmList := &corev1.ConfigMapList{}
+
+		watcher, err := c.k8sClient.Watch(ctx, cmList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("metadata.name", c.configMapName),
+			Namespace:     c.configMapNamespace,
+		})
+		if err != nil {
+			c.log.Error(err, "Failed to create ConfigMap watcher; will retry in 5s")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				c.log.Info("Received context cancellation, shutting down runtime configuration watcher")
+				watcher.Stop()
+				break LOOP
+
+			case event, open := <-watcher.ResultChan():
+				if !open {
+					c.log.Info("Received closed channel from ConfigMap watcher, will recreate")
+					watcher.Stop()
+					continue LOOP
+				}
+
+				switch event.Type {
+				case watch.Deleted:
+					c.handleDeletion()
+
+				case watch.Added:
+					if err := c.handleChange(event); err != nil {
+						c.log.Error(err, "Failed to handle new runtime configuration for issuerRef")
+					}
+
+				case watch.Modified:
+					if err := c.handleChange(event); err != nil {
+						c.log.Error(err, "Failed to handle runtime configuration issuerRef change")
+					}
+
+				case watch.Bookmark:
+					// Ignore bookmark events.
+
+				case watch.Error:
+					err, ok := event.Object.(error)
+					if !ok {
+						c.log.Error(nil, "Got an error event when watching runtime configuration but unable to determine further information")
+					} else {
+						c.log.Error(err, "Got an error event when watching runtime configuration")
+					}
+
+				default:
+					c.log.Info("Got unknown event for runtime configuration ConfigMap; ignoring", "event-type", string(event.Type))
+				}
+			}
+		}
+	}
+
+	c.log.Info("Stopped runtime configuration watcher")
+}
+
+// handleChange updates the active configuration from the ConfigMap data in the
+// event and broadcasts to subscribers.
+func (c *configmap) handleChange(event watch.Event) error {
+	cm, ok := event.Object.(*corev1.ConfigMap)
+	if !ok {
+		return fmt.Errorf("got unexpected type for runtime configuration source; this is likely a programming error")
+	}
+
+	issuerRef := cmmeta.IssuerReference{}
+
+	var dataErrs []error
+	var exists bool
+
+	issuerRef.Name, exists = cm.Data[issuerNameKey]
+	if !exists || len(issuerRef.Name) == 0 {
+		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data: %s", issuerNameKey))
+	}
+
+	issuerRef.Kind, exists = cm.Data[issuerKindKey]
+	if !exists || len(issuerRef.Kind) == 0 {
+		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data: %s", issuerKindKey))
+	}
+
+	issuerRef.Group, exists = cm.Data[issuerGroupKey]
+	if !exists || len(issuerRef.Group) == 0 {
+		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data; %s", issuerGroupKey))
+	}
+
+	if len(dataErrs) > 0 {
+		return errors.Join(dataErrs...)
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.active = Config{IssuerRef: issuerRef}
+	c.log.Info("Changed active issuerRef in response to runtime configuration ConfigMap",
+		"issuer-name", c.active.IssuerRef.Name,
+		"issuer-kind", c.active.IssuerRef.Kind,
+		"issuer-group", c.active.IssuerRef.Group,
+	)
+
+	return nil
+}
+
+// handleDeletion reverts the active configuration to the static fallback.
+func (c *configmap) handleDeletion() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.static.IssuerRef.Name == "" {
+		c.log.Info("Runtime issuance configuration was deleted and no issuerRef was configured at install time; issuance will fail until runtime configuration is reinstated")
+	} else {
+		c.log.Info("Runtime issuance configuration was deleted; issuance will revert to original issuerRef configured at install time")
+	}
+
+	c.active = c.static
+}
+
+// Config returns the current active runtime configuration.
+func (c *configmap) Config() Config {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.active
+}
+

--- a/internal/csi/runtimeconfig/configmap.go
+++ b/internal/csi/runtimeconfig/configmap.go
@@ -221,4 +221,3 @@ func (c *configmap) Config() Config {
 	defer c.lock.RUnlock()
 	return c.active
 }
-

--- a/internal/csi/runtimeconfig/memory.go
+++ b/internal/csi/runtimeconfig/memory.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeconfig
+
+import (
+	"context"
+	"sync"
+)
+
+// memory is an implementation of Interface that holds the runtime
+// configuration in memory. Accepts an optional channel to update the configuration.
+type memory struct {
+	// active is the current runtime configuration.
+	active Config
+
+	// lock guards access to active.
+	lock sync.RWMutex
+}
+
+// NewMemory constructs a new memory implementation of Interface. It sets the
+// initial configuration to initial and listens to the updates channel (if
+// non-nil) for configuration changes.
+func NewMemory(ctx context.Context, initial Config, updates <-chan Config) Interface {
+	m := &memory{
+		active: initial,
+	}
+
+	if updates != nil {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+
+				case cfg := <-updates:
+					m.lock.Lock()
+					m.active = cfg
+					m.lock.Unlock()
+				}
+			}
+		}()
+	}
+
+	return m
+}
+
+// Config returns the current runtime configuration in memory.
+func (m *memory) Config() Config {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.active
+}
+

--- a/internal/csi/runtimeconfig/memory.go
+++ b/internal/csi/runtimeconfig/memory.go
@@ -64,4 +64,3 @@ func (m *memory) Config() Config {
 	defer m.lock.RUnlock()
 	return m.active
 }
-

--- a/internal/csi/runtimeconfig/runtimeconfig.go
+++ b/internal/csi/runtimeconfig/runtimeconfig.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package runtimeconfig provides the runtime-configurable settings for the
+// SPIFFE CSI driver, including support for watching a Kubernetes ConfigMap for
+// live issuer configuration updates.
+package runtimeconfig
+
+import (
+	"context"
+	"fmt"
+
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Config holds the runtime-configurable settings for the SPIFFE CSI driver.
+type Config struct {
+	// IssuerRef is the cert-manager issuer reference to use when creating
+	// CertificateRequests.
+	IssuerRef cmmeta.IssuerReference
+}
+
+// Interface provides the current runtime configuration.
+type Interface interface {
+	// Config returns the current runtime configuration.
+	Config() Config
+}
+
+// DynamicConfig holds the configuration for the ConfigMap-based runtime
+// configuration source.
+type DynamicConfig struct {
+	// ConfigMapName is the name of the ConfigMap to watch for runtime
+	// configuration.
+	ConfigMapName string
+
+	// ConfigMapNamespace is the namespace of the ConfigMap to watch for
+	// runtime configuration.
+	ConfigMapNamespace string
+}
+
+// Options configures the runtime configuration source.
+type Options struct {
+	// StaticConfig is the static configuration to use when no dynamic
+	// configuration source is provided, or as the fallback when the dynamic
+	// configuration source is unavailable.
+	StaticConfig Config
+
+	// DynamicConfig configures an optional ConfigMap-based runtime
+	// configuration source.
+	DynamicConfig DynamicConfig
+}
+
+// New constructs the appropriate Interface based on the provided options.
+// When opts.DynamicConfig.ConfigMapName is set, a ConfigMap watcher is
+// constructed and c must not be nil. When only a static IssuerRef is provided,
+// an in-memory implementation is returned. Returns an error if neither
+// StaticConfig.IssuerRef.Name nor DynamicConfig.ConfigMapName is set, or if
+// ConfigMapName is set but c is nil. The logger is extracted from ctx via
+// logr.FromContext.
+func New(ctx context.Context, c client.WithWatch, opts Options) (Interface, error) {
+	if opts.DynamicConfig.ConfigMapName != "" {
+		if c == nil {
+			return nil, fmt.Errorf("a Kubernetes client is required when ConfigMapName is set")
+		}
+		return NewConfigMap(ctx, c, opts.DynamicConfig.ConfigMapName, opts.DynamicConfig.ConfigMapNamespace, opts.StaticConfig), nil
+	}
+
+	if opts.StaticConfig.IssuerRef.Name == "" {
+		return nil, fmt.Errorf("runtime issuance configuration is required if no issuer is provided at startup")
+	}
+
+	return NewMemory(ctx, opts.StaticConfig, nil), nil
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

The csi-driver-spiffe approver currently requires `approver-policy` because cert-manager's built-in auto-approver conflicts with its strict SPIFFE identity validation — you have to disable the default approver, and that means nothing else approves non-SPIFFE `CertificateRequest`s either.

This PR adds an `--auto-approve-non-spiffe` flag that lets the approver handle all `CertificateRequest`s, removing the need for `approver-policy` in simple deployments. When enabled, the approver applies a three-way decision:

- **Unannotated request targeting the configured SPIFFE issuer** → denied. This preserves the security model: nobody can obtain a SPIFFE certificate outside the normal validation path.
- **Unannotated request targeting any other issuer** → approved unconditionally.
- **SPIFFE-annotated request** → evaluated by the existing strict evaluator, unchanged.

The flag defaults to `false`; existing deployments are unaffected.

The PR also includes a prerequisite refactor (first commit) that extracts the runtime ConfigMap watcher from `driver.go` into a new `internal/csi/runtimeconfig` package, modelled on the existing `internal/csi/rootca` package. This gives the approver a clean abstraction for tracking the live SPIFFE issuer reference (including ConfigMap-based runtime updates) without duplicating the watcher logic.

### Kind

/kind feature

### Release Note

```release-note
Added `--auto-approve-non-spiffe` flag to the approver. When enabled, the approver auto-approves CertificateRequests that do not carry the SPIFFE identity annotation and do not target the configured SPIFFE issuer, allowing csi-driver-spiffe to act as a drop-in replacement for cert-manager's built-in auto-approver without requiring approver-policy.
```