### PR TITLE
feat: add --use-own-service-account mode to CSI driver

### DIFF
--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -328,6 +328,15 @@ volumeMounts:
 > ```
 
 Configures the hostPath directory that the driver will write and mount volumes from.
+#### **app.driver.useOwnServiceAccount** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+When set to true, the CSI driver will use its own ServiceAccount credentials when creating CertificateRequests, rather than impersonating the mounting pod's ServiceAccount.  
+  
+When enabled, the Approver changes its validation strategy: instead of verifying the SPIFFE identity matches the requesting pod's ServiceAccount, it verifies that the requester is the driver's own ServiceAccount.
 #### **app.driver.resources** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -100,6 +100,9 @@ spec:
           {{- if .Values.app.extraCertificateRequestAnnotations }}
             - --extra-certificate-request-annotations={{ .Values.app.extraCertificateRequestAnnotations }}
           {{- end }}
+          {{- if .Values.app.driver.useOwnServiceAccount }}
+            - --use-own-service-account=true
+          {{- end }}
           env:
             - name: NODE_ID
               valueFrom:

--- a/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           - --leader-election-namespace=$(POD_NAMESPACE)
           - "--metrics-bind-address=:{{.Values.app.approver.metrics.port}}"
           - "--readiness-probe-bind-address=:{{.Values.app.approver.readinessProbe.port}}"
+          {{- if .Values.app.driver.useOwnServiceAccount }}
+          - --use-own-service-account=true
+          - "--driver-service-account=system:serviceaccount:{{ .Release.Namespace }}:{{ include "cert-manager-csi-driver-spiffe.name" . }}"
+          {{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -253,6 +253,9 @@
         "sourceCABundle": {
           "$ref": "#/$defs/helm-values.app.driver.sourceCABundle"
         },
+        "useOwnServiceAccount": {
+          "$ref": "#/$defs/helm-values.app.driver.useOwnServiceAccount"
+        },
         "volumeFileName": {
           "$ref": "#/$defs/helm-values.app.driver.volumeFileName"
         },
@@ -409,6 +412,11 @@
     },
     "helm-values.app.driver.sourceCABundle": {
       "description": "Optional file containing a CA bundle that will be propagated to managed volumes."
+    },
+    "helm-values.app.driver.useOwnServiceAccount": {
+      "default": false,
+      "description": "When set to true, the CSI driver will use its own ServiceAccount credentials when creating CertificateRequests, rather than impersonating the mounting pod's ServiceAccount.\n\nWhen enabled, the Approver changes its validation strategy: instead of verifying the SPIFFE identity matches the requesting pod's ServiceAccount, it verifies that the requester is the driver's own ServiceAccount.",
+      "type": "boolean"
     },
     "helm-values.app.driver.volumeFileName": {
       "additionalProperties": false,

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -171,6 +171,15 @@ app:
     # Configures the hostPath directory that the driver will write and mount volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver
 
+    # When set to true, the CSI driver will use its own ServiceAccount credentials
+    # when creating CertificateRequests, rather than impersonating the mounting
+    # pod's ServiceAccount.
+    #
+    # When enabled, the Approver changes its validation strategy: instead of
+    # verifying the SPIFFE identity matches the requesting pod's ServiceAccount,
+    # it verifies that the requester is the driver's own ServiceAccount.
+    useOwnServiceAccount: false
+
     # Kubernetes pod resource limits for cert-manager-csi-driver-spiffe
     #
     # For example:

--- a/internal/approver/app/app.go
+++ b/internal/approver/app/app.go
@@ -83,6 +83,8 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			evaluator := evaluator.New(evaluator.Options{
 				TrustDomain:                opts.CertManager.TrustDomain,
 				CertificateRequestDuration: opts.CertManager.CertificateRequestDuration,
+				UseOwnServiceAccount:       opts.CertManager.UseOwnServiceAccount,
+				DriverServiceAccount:       opts.CertManager.DriverServiceAccount,
 			})
 
 			if err := controller.AddApprover(ctx, opts.Logr, controller.Options{

--- a/internal/approver/app/options/options.go
+++ b/internal/approver/app/options/options.go
@@ -62,6 +62,17 @@ type OptionsCertManager struct {
 	// CertificateRequestDuration is the duration the evaluator will enforce
 	// CertificateRequest request for.
 	CertificateRequestDuration time.Duration
+
+	// UseOwnServiceAccount, when true, changes the approval validation strategy.
+	// Instead of verifying that the SPIFFE identity in the CSR matches the
+	// requesting pod's ServiceAccount, the approver verifies that the requester
+	// is the driver's own ServiceAccount (DriverServiceAccount).
+	UseOwnServiceAccount bool
+
+	// DriverServiceAccount is the full Kubernetes username of the CSI driver's
+	// ServiceAccount (e.g. "system:serviceaccount:cert-manager:spiffe.csi.cert-manager.io").
+	// Only used when UseOwnServiceAccount is true.
+	DriverServiceAccount string
 }
 
 func New() *Options {
@@ -78,6 +89,16 @@ func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
 
 	fs.DurationVar(&o.CertManager.CertificateRequestDuration, "certificate-request-duration", time.Hour,
 		"The duration which is enforced for requests to have.")
+
+	fs.BoolVar(&o.CertManager.UseOwnServiceAccount, "use-own-service-account", false,
+		"When true, the approver validates that CertificateRequests are made by the "+
+			"driver's own ServiceAccount (--driver-service-account) rather than by the "+
+			"mounting pod's ServiceAccount.")
+
+	fs.StringVar(&o.CertManager.DriverServiceAccount, "driver-service-account", "",
+		"Full Kubernetes username of the CSI driver's ServiceAccount "+
+			"(e.g. \"system:serviceaccount:cert-manager:spiffe.csi.cert-manager.io\"). "+
+			"Required when --use-own-service-account is true.")
 
 	// allow issuer-* args to still be passed to avoid a backwards incompatible change
 	var dummyIssuerRefName, dummyIssuerRefKind, dummyIssuerRefGroup string

--- a/internal/approver/evaluator/evaluator.go
+++ b/internal/approver/evaluator/evaluator.go
@@ -49,6 +49,16 @@ type Options struct {
 	// CertificateRequestDuration is the duration that users _must_ request for,
 	// else the request will be denied.
 	CertificateRequestDuration time.Duration
+
+	// UseOwnServiceAccount, when true, changes the identity validation strategy.
+	// Instead of verifying that the SPIFFE identity in the CSR matches the
+	// requesting pod's ServiceAccount, the approver verifies that the requester
+	// is the driver's own ServiceAccount (DriverServiceAccount).
+	UseOwnServiceAccount bool
+
+	// DriverServiceAccount is the full Kubernetes username of the CSI driver's
+	// ServiceAccount. Only used when UseOwnServiceAccount is true.
+	DriverServiceAccount string
 }
 
 // internal is the internal implementation of the evaluator that should be used
@@ -61,6 +71,13 @@ type internal struct {
 	// certificateRequestDuration is the duration that users _must_ request for,
 	// else the request will be denied.
 	certificateRequestDuration time.Duration
+
+	// useOwnServiceAccount controls which identity validation strategy is used.
+	useOwnServiceAccount bool
+
+	// driverServiceAccount is the full Kubernetes username of the CSI driver's
+	// ServiceAccount. Only used when useOwnServiceAccount is true.
+	driverServiceAccount string
 }
 
 // New constructs a new evaluator.
@@ -68,6 +85,8 @@ func New(opts Options) Interface {
 	return &internal{
 		trustDomain:                opts.TrustDomain,
 		certificateRequestDuration: opts.CertificateRequestDuration,
+		useOwnServiceAccount:       opts.UseOwnServiceAccount,
+		driverServiceAccount:       opts.DriverServiceAccount,
 	}
 }
 
@@ -108,8 +127,14 @@ func (i *internal) Evaluate(req *cmapi.CertificateRequest) error {
 		return fmt.Errorf("request contains wrong usages, exp=%v got=%v", requiredUsages, req.Spec.Usages)
 	}
 
-	if err := i.validateIdentity(csr, req.Spec.Username); err != nil {
-		return err
+	if i.useOwnServiceAccount {
+		if err := i.validateDriverServiceAccount(csr, req.Spec.Username); err != nil {
+			return err
+		}
+	} else {
+		if err := i.validateIdentity(csr, req.Spec.Username); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/approver/evaluator/identity.go
+++ b/internal/approver/evaluator/identity.go
@@ -22,6 +22,33 @@ import (
 	"strings"
 )
 
+// validateDriverServiceAccount validates that:
+//   - the CSR contains exactly one URI SAN with the spiffe:// scheme and the
+//     correct trust domain, and
+//   - the CertificateRequest was made by the driver's own ServiceAccount.
+//
+// Used when UseOwnServiceAccount is true.
+func (i *internal) validateDriverServiceAccount(csr *x509.CertificateRequest, username string) error {
+	if len(csr.URIs) != 1 {
+		return fmt.Errorf("expected exactly 1 SPIFFE URI present on request, got=%d", len(csr.URIs))
+	}
+
+	if csr.URIs[0].Scheme != "spiffe" {
+		return fmt.Errorf("URI scheme is not spiffe: %s", csr.URIs[0].Scheme)
+	}
+
+	if csr.URIs[0].Host != i.trustDomain {
+		return fmt.Errorf("unexpected trust domain, exp=%q got=%q", i.trustDomain, csr.URIs[0].Host)
+	}
+
+	if username != i.driverServiceAccount {
+		return fmt.Errorf("request must be made by the csi-driver-spiffe ServiceAccount, exp=%q got=%q",
+			i.driverServiceAccount, username)
+	}
+
+	return nil
+}
+
 // validateIdentity validates that the SPIFFE ID contained in the X.509
 // certificate request matches that in the username.
 // The username should be the Username as it appears on the CertificateRequest.

--- a/internal/csi/app/app.go
+++ b/internal/csi/app/app.go
@@ -79,8 +79,9 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				CertificateFileName: opts.Volume.CertificateFileName,
 				KeyFileName:         opts.Volume.KeyFileName,
 
-				CAFileName: opts.Volume.CAFileName,
-				RootCAs:    rootCA,
+				CAFileName:           opts.Volume.CAFileName,
+				RootCAs:              rootCA,
+				UseOwnServiceAccount: opts.Driver.UseOwnServiceAccount,
 			})
 			if err != nil {
 				return err

--- a/internal/csi/app/options/options.go
+++ b/internal/csi/app/options/options.go
@@ -52,6 +52,13 @@ type OptionsDriver struct {
 
 	// Endpoint is the endpoint which is used to listen for gRPC requests.
 	Endpoint string
+
+	// UseOwnServiceAccount, when true, causes the driver to create
+	// CertificateRequests using its own ServiceAccount credentials rather than
+	// impersonating the mounting pod's ServiceAccount. When enabled, the
+	// approver is not required; a ValidatingAdmissionPolicy should be deployed
+	// instead.
+	UseOwnServiceAccount bool
 }
 
 // OptionsCertManager is options specific to cert-manager CertificateRequests.
@@ -116,6 +123,11 @@ func (o *Options) addDriverFlags(fs *pflag.FlagSet) {
 		"Path to the in-memory data directory used to store data.")
 	fs.StringVar(&o.Driver.Endpoint, "endpoint", "",
 		"Path to the unix socket used to listen for gRPC requests.")
+	fs.BoolVar(&o.Driver.UseOwnServiceAccount, "use-own-service-account", false,
+		"When true, the driver creates CertificateRequests using its own "+
+			"ServiceAccount credentials rather than impersonating the mounting pod's "+
+			"ServiceAccount. When enabled, the approver is not required; a "+
+			"ValidatingAdmissionPolicy should be deployed instead.")
 }
 
 func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -31,7 +31,7 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	cmversioned "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	"github.com/cert-manager/csi-lib/driver"
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/manager/util"
@@ -110,6 +110,11 @@ type Options struct {
 
 	// IssuanceConfigMapNamespace is the namespace of the ConfigMap to watch for issuance configuration
 	IssuanceConfigMapNamespace string
+
+	// UseOwnServiceAccount, when true, causes the driver to create
+	// CertificateRequests using its own ServiceAccount credentials rather than
+	// impersonating the mounting pod's ServiceAccount.
+	UseOwnServiceAccount bool
 }
 
 // Driver is used for running the actual CSI driver. Driver will respond to
@@ -246,9 +251,17 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 	d.camanager = newCAManager(log, store, opts.RootCAs,
 		opts.CertificateFileName, opts.KeyFileName, opts.CAFileName)
 
-	cmclient, err := cmclient.NewForConfig(opts.RestConfig)
+	cmclient, err := cmversioned.NewForConfig(opts.RestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build cert-manager client: %w", err)
+	}
+
+	// In own-service-account mode, ClientForMetadata is left nil so the
+	// manager falls back to Client (the driver's own SA). In the default mode,
+	// we supply a per-pod impersonation client derived from the pod's token.
+	var clientForMeta manager.ClientForMetadataFunc
+	if !opts.UseOwnServiceAccount {
+		clientForMeta = util.ClientForMetadataTokenRequestEmptyAud(opts.RestConfig)
 	}
 
 	k8sClient, err := client.NewWithWatch(opts.RestConfig, client.Options{})
@@ -265,9 +278,8 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 		NodeID:        opts.NodeID,
 		Store:         d.store,
 		Manager: manager.NewManagerOrDie(manager.Options{
-			Client: cmclient,
-			// Use Pod's service account to request CertificateRequests.
-			ClientForMetadata:    util.ClientForMetadataTokenRequestEmptyAud(opts.RestConfig),
+			Client:               cmclient,
+			ClientForMetadata:    clientForMeta,
 			MaxRequestsPerVolume: 1,
 			MetadataReader:       d.store,
 			Clock:                clock.RealClock{},


### PR DESCRIPTION
### Pull Request Motivation

Currently the CSI driver impersonates each mounting pod's ServiceAccount when creating CertificateRequests. This requires the dedicated Approver component to validate that the SPIFFE identity in each request matches the requesting pod's identity.

This PR adds an alternative operational mode (`--use-own-service-account` / `app.driver.useOwnServiceAccount: true`) where the driver uses its own ServiceAccount for all CertificateRequest creation. This simplifies deployment by allowing cert-manager's built-in default approver to be used instead of the dedicated SPIFFE approver.

When this mode is enabled, the Approver changes its validation strategy: instead of verifying that the SPIFFE identity in the CSR matches the requesting pod's ServiceAccount, it verifies:
- The CSR contains exactly one URI SAN with the `spiffe://` scheme and the correct trust domain
- The requester is the driver's own ServiceAccount (`--driver-service-account`)

All other CSR shape validation (duration, signature, forbidden extensions, usages, isCA) is unchanged in both modes.

The SPIFFE URI SAN in issued certificates continues to reflect the mounting pod's identity unchanged; only the Kubernetes actor creating the CertificateRequest changes.

### Kind

/kind feature

### Release Note

```release-note
Add --use-own-service-account flag and app.driver.useOwnServiceAccount Helm value. When enabled, the driver uses its own ServiceAccount to create CertificateRequests instead of impersonating the mounting pod's ServiceAccount. The Approver adapts its validation to verify the requester is the driver's ServiceAccount rather than matching the SPIFFE identity to the pod's ServiceAccount.
```