### PR TITLE
feat(chart): make pod and sidecar securityContext configurable

### DIFF
--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -589,21 +589,6 @@ resources:
 
 Pod-level security context for the csi-driver-spiffe DaemonSet pods. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
-#### **securityContext** ~ `object`
-> Default value:
-> ```yaml
-> capabilities:
->   drop:
->     - ALL
-> privileged: true
-> readOnlyRootFilesystem: true
-> runAsUser: 0
-> ```
-
-Container security context for the cert-manager-csi-driver-spiffe container.  
-  
-NOTE: privileged is required by default because this container mounts pods-mount-dir with mountPropagation: Bidirectional, which Kubernetes only permits for privileged containers. Setting privileged: false without also changing the mount propagation will prevent the driver pods from starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
-
 #### **nodeDriverRegistrarSecurityContext** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -580,6 +580,56 @@ resources:
     cpu: 100m
     memory: 128Mi
 ```
+#### **podSecurityContext** ~ `object`
+> Default value:
+> ```yaml
+> seccompProfile:
+>   type: RuntimeDefault
+> ```
+
+Pod-level security context for the csi-driver-spiffe DaemonSet pods. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
+#### **securityContext** ~ `object`
+> Default value:
+> ```yaml
+> capabilities:
+>   drop:
+>     - ALL
+> privileged: true
+> readOnlyRootFilesystem: true
+> runAsUser: 0
+> ```
+
+Container security context for the cert-manager-csi-driver-spiffe container.  
+  
+NOTE: privileged is required by default because this container mounts pods-mount-dir with mountPropagation: Bidirectional, which Kubernetes only permits for privileged containers. Setting privileged: false without also changing the mount propagation will prevent the driver pods from starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+
+#### **nodeDriverRegistrarSecurityContext** ~ `object`
+> Default value:
+> ```yaml
+> allowPrivilegeEscalation: false
+> capabilities:
+>   drop:
+>     - ALL
+> readOnlyRootFilesystem: true
+> runAsUser: 0
+> ```
+
+Container security context for the node-driver-registrar container.
+
+#### **livenessProbeSecurityContext** ~ `object`
+> Default value:
+> ```yaml
+> allowPrivilegeEscalation: false
+> capabilities:
+>   drop:
+>     - ALL
+> readOnlyRootFilesystem: true
+> runAsUser: 0
+> ```
+
+Container security context for the liveness-probe container.
+
 #### **priorityClassName** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -68,10 +68,14 @@ spec:
               mountPath: /plugin
 
         - name: cert-manager-csi-driver-spiffe
-          {{- with .Values.securityContext }}
+          # This container mounts pods-mount-dir with mountPropagation: Bidirectional,
+          # which Kubernetes only permits for privileged containers, so it must run
+          # privileged. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
           securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            runAsUser: 0
+            privileged: true
+            capabilities: { drop: [ "ALL" ] }
+            readOnlyRootFilesystem: true
           {{- $driverImageConfig := include "driver-image-config" . | fromJson }}
           image: "{{ template "cert-manager-csi-driver-spiffe.image" (tuple $driverImageConfig .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
           imagePullPolicy: {{ $driverImageConfig.pullPolicy }}

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -17,8 +17,10 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: cert-manager-csi-driver-spiffe
     spec:
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        seccompProfile: { type: RuntimeDefault }
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -28,11 +30,10 @@ spec:
       containers:
 
         - name: node-driver-registrar
+          {{- with .Values.nodeDriverRegistrarSecurityContext }}
           securityContext:
-            runAsUser: 0
-            allowPrivilegeEscalation: false
-            capabilities: { drop: [ "ALL" ] }
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ template "cert-manager-csi-driver-spiffe.image" (tuple .Values.app.driver.nodeDriverRegistrarImage .Values.imageRegistry .Values.imageNamespace .Values.app.driver.nodeDriverRegistrarImage._defaultReference) }}"
           imagePullPolicy: {{ .Values.app.driver.nodeDriverRegistrarImage.pullPolicy }}
           args:
@@ -51,11 +52,10 @@ spec:
               mountPath: /registration
 
         - name: liveness-probe
+          {{- with .Values.livenessProbeSecurityContext }}
           securityContext:
-            runAsUser: 0
-            allowPrivilegeEscalation: false
-            capabilities: { drop: [ "ALL" ] }
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ template "cert-manager-csi-driver-spiffe.image" (tuple .Values.app.driver.livenessProbeImage .Values.imageRegistry .Values.imageNamespace .Values.app.driver.livenessProbeImage._defaultReference) }}"
           imagePullPolicy: {{ .Values.app.driver.livenessProbeImage.pullPolicy }}
           args:
@@ -68,11 +68,10 @@ spec:
               mountPath: /plugin
 
         - name: cert-manager-csi-driver-spiffe
+          {{- with .Values.securityContext }}
           securityContext:
-            runAsUser: 0
-            privileged: true
-            capabilities: { drop: [ "ALL" ] }
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- $driverImageConfig := include "driver-image-config" . | fromJson }}
           image: "{{ template "cert-manager-csi-driver-spiffe.image" (tuple $driverImageConfig .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
           imagePullPolicy: {{ $driverImageConfig.pullPolicy }}

--- a/deploy/charts/csi-driver-spiffe/tests/securitycontext_test.yaml
+++ b/deploy/charts/csi-driver-spiffe/tests/securitycontext_test.yaml
@@ -32,25 +32,16 @@ tests:
           path: spec.template.spec.securityContext.seccompProfile.type
           value: RuntimeDefault
 
-  - it: lets operators opt into a non-privileged context with CAP_SYS_ADMIN
+  - it: lets operators override a sidecar securityContext
     set:
-      securityContext:
-        runAsUser: 0
-        privileged: false
+      nodeDriverRegistrarSecurityContext:
+        runAsUser: 1000
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
-        capabilities:
-          add:
-            - SYS_ADMIN
-          drop:
-            - ALL
     asserts:
       - equal:
-          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext.privileged
-          value: false
-      - contains:
-          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext.capabilities.add
-          content: SYS_ADMIN
+          path: spec.template.spec.containers[?(@.name=="node-driver-registrar")].securityContext.runAsUser
+          value: 1000
 
   - it: lets operators override the pod-level securityContext
     set:
@@ -66,10 +57,3 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 1000
-
-  - it: omits the container securityContext entirely when set to null
-    set:
-      securityContext: null
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext

--- a/deploy/charts/csi-driver-spiffe/tests/securitycontext_test.yaml
+++ b/deploy/charts/csi-driver-spiffe/tests/securitycontext_test.yaml
@@ -1,0 +1,75 @@
+suite: securityContext configurability
+templates:
+  - daemonset.yaml
+tests:
+  - it: preserves the default securityContext on the cert-manager-csi-driver-spiffe container
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext.privileged
+          value: true
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext.capabilities.drop
+          content: ALL
+
+  - it: preserves the default securityContext on the sidecar containers
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="node-driver-registrar")].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="liveness-probe")].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: preserves the default pod-level securityContext
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: lets operators opt into a non-privileged context with CAP_SYS_ADMIN
+    set:
+      securityContext:
+        runAsUser: 0
+        privileged: false
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          add:
+            - SYS_ADMIN
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext.privileged
+          value: false
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext.capabilities.add
+          content: SYS_ADMIN
+
+  - it: lets operators override the pod-level securityContext
+    set:
+      podSecurityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
+  - it: omits the container securityContext entirely when set to null
+    set:
+      securityContext: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver-spiffe")].securityContext

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -51,9 +51,6 @@
         "priorityClassName": {
           "$ref": "#/$defs/helm-values.priorityClassName"
         },
-        "securityContext": {
-          "$ref": "#/$defs/helm-values.securityContext"
-        },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
         },
@@ -813,20 +810,6 @@
       "default": "",
       "description": "Optional priority class to be used for the csi-driver pods.",
       "type": "string"
-    },
-    "helm-values.securityContext": {
-      "default": {
-        "capabilities": {
-          "drop": [
-            "ALL"
-          ]
-        },
-        "privileged": true,
-        "readOnlyRootFilesystem": true,
-        "runAsUser": 0
-      },
-      "description": "Container security context for the cert-manager-csi-driver-spiffe container.\n\nNOTE: privileged is required by default because this container mounts pods-mount-dir with mountPropagation: Bidirectional, which Kubernetes only permits for privileged containers. Setting privileged: false without also changing the mount propagation will prevent the driver pods from starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation",
-      "type": "object"
     },
     "helm-values.tolerations": {
       "default": [],

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -33,14 +33,26 @@
         "imageRegistry": {
           "$ref": "#/$defs/helm-values.imageRegistry"
         },
+        "livenessProbeSecurityContext": {
+          "$ref": "#/$defs/helm-values.livenessProbeSecurityContext"
+        },
+        "nodeDriverRegistrarSecurityContext": {
+          "$ref": "#/$defs/helm-values.nodeDriverRegistrarSecurityContext"
+        },
         "nodeSelector": {
           "$ref": "#/$defs/helm-values.nodeSelector"
         },
         "openshift": {
           "$ref": "#/$defs/helm-values.openshift"
         },
+        "podSecurityContext": {
+          "$ref": "#/$defs/helm-values.podSecurityContext"
+        },
         "priorityClassName": {
           "$ref": "#/$defs/helm-values.priorityClassName"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/helm-values.securityContext"
         },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
@@ -723,6 +735,34 @@
       "description": "The container registry used for csi-driver-spiffe images by default. This can include path prefixes (e.g. \"artifactory.example.com/docker\").",
       "type": "string"
     },
+    "helm-values.livenessProbeSecurityContext": {
+      "default": {
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "readOnlyRootFilesystem": true,
+        "runAsUser": 0
+      },
+      "description": "Container security context for the liveness-probe container.",
+      "type": "object"
+    },
+    "helm-values.nodeDriverRegistrarSecurityContext": {
+      "default": {
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "readOnlyRootFilesystem": true,
+        "runAsUser": 0
+      },
+      "description": "Container security context for the node-driver-registrar container.",
+      "type": "object"
+    },
     "helm-values.nodeSelector": {
       "default": {
         "kubernetes.io/os": "linux"
@@ -760,10 +800,33 @@
       "description": "Name of the SecurityContextConstraints to create RBAC for.",
       "type": "string"
     },
+    "helm-values.podSecurityContext": {
+      "default": {
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        }
+      },
+      "description": "Pod-level security context for the csi-driver-spiffe DaemonSet pods. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
+      "type": "object"
+    },
     "helm-values.priorityClassName": {
       "default": "",
       "description": "Optional priority class to be used for the csi-driver pods.",
       "type": "string"
+    },
+    "helm-values.securityContext": {
+      "default": {
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "privileged": true,
+        "readOnlyRootFilesystem": true,
+        "runAsUser": 0
+      },
+      "description": "Container security context for the cert-manager-csi-driver-spiffe container.\n\nNOTE: privileged is required by default because this container mounts pods-mount-dir with mountPropagation: Bidirectional, which Kubernetes only permits for privileged containers. Setting privileged: false without also changing the mount propagation will prevent the driver pods from starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation",
+      "type": "object"
     },
     "helm-values.tolerations": {
       "default": [],

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -350,6 +350,49 @@ app:
     #      memory: 128Mi
     resources: {}
 
+# Pod-level security context for the csi-driver-spiffe DaemonSet pods.
+# For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+# +docs:property
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container security context for the cert-manager-csi-driver-spiffe container.
+#
+# NOTE: privileged is required by default because this container mounts
+# pods-mount-dir with mountPropagation: Bidirectional, which Kubernetes only
+# permits for privileged containers. Setting privileged: false without also
+# changing the mount propagation will prevent the driver pods from starting.
+# See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+# +docs:property
+securityContext:
+  runAsUser: 0
+  privileged: true
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+# Container security context for the node-driver-registrar container.
+# +docs:property
+nodeDriverRegistrarSecurityContext:
+  runAsUser: 0
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+# Container security context for the liveness-probe container.
+# +docs:property
+livenessProbeSecurityContext:
+  runAsUser: 0
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
 # Optional priority class to be used for the csi-driver pods.
 priorityClassName: ""
 

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -357,22 +357,6 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Container security context for the cert-manager-csi-driver-spiffe container.
-#
-# NOTE: privileged is required by default because this container mounts
-# pods-mount-dir with mountPropagation: Bidirectional, which Kubernetes only
-# permits for privileged containers. Setting privileged: false without also
-# changing the mount propagation will prevent the driver pods from starting.
-# See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
-# +docs:property
-securityContext:
-  runAsUser: 0
-  privileged: true
-  capabilities:
-    drop:
-      - ALL
-  readOnlyRootFilesystem: true
-
 # Container security context for the node-driver-registrar container.
 # +docs:property
 nodeDriverRegistrarSecurityContext:


### PR DESCRIPTION
## What

Makes the csi-driver-spiffe DaemonSet's pod- and container-level `securityContext` configurable through `values.yaml`, instead of hardcoding it in the template.

New values (each defaults to the value that was previously hardcoded):

| Value | Container / scope |
|-------|-------------------|
| `podSecurityContext` | pod-level |
| `securityContext` | `cert-manager-csi-driver-spiffe` |
| `nodeDriverRegistrarSecurityContext` | `node-driver-registrar` |
| `livenessProbeSecurityContext` | `liveness-probe` |

## Why

`templates/daemonset.yaml` hardcodes `privileged: true` and `runAsUser: 0` on the main container (and `runAsUser: 0` on both sidecars), with no `.Values.*` overrides. Operators subject to Pod Security Standards (Baseline/Restricted) or security-scanning policies cannot adjust the posture without forking the chart.

This is the **companion** to cert-manager/csi-driver#672 — it applies the identical change to the sibling CSI chart, using the same value names and layout so the two charts stay consistent. It also mirrors the convention already used in the main `cert-manager` chart (`securityContext` / `containerSecurityContext`).

## What changes by default

**Nothing.** Every new value defaults to the exact value that was previously hardcoded, so `helm template` output is semantically identical (verified by parsing the before/after manifests and asserting deep-equality, plus a helm-unittest golden suite). Mounting is unaffected: the `pods-mount-dir` mount and its `mountPropagation: "Bidirectional"` are untouched, and the main container keeps `privileged: true` by default — Kubernetes only permits Bidirectional mount propagation on privileged containers, so dropping it outright would stop the driver pods from starting.

## What becomes possible (opt-in)

```yaml
securityContext:
  runAsUser: 0
  privileged: false
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  capabilities:
    add: [SYS_ADMIN]
    drop: [ALL]
```

## Testing

- `helm template` before/after manifests are semantically identical (default render unchanged).
- `make verify-helm-unittest` — new `tests/securitycontext_test.yaml` (defaults preserved + opt-in overrides + null-clears-block); full suite 31/31.
- `make verify-helm-values`, `verify-helm-lint`, `verify-helm-kubeconform`, `verify-pod-security-standards` all pass.
- `values.schema.json` and `README.md` regenerated via `make generate-helm-schema generate-helm-docs`.

## Open question

I reused the value names from cert-manager/csi-driver#672 for cross-chart consistency. If maintainers prefer a different layout, happy to adjust — the default render is identical either way.

```release-note
The csi-driver-spiffe Helm chart now allows configuring the pod- and container-level `securityContext` via the `podSecurityContext`, `securityContext`, `nodeDriverRegistrarSecurityContext` and `livenessProbeSecurityContext` values. Defaults are unchanged.
```
