### PR TITLE
fix(deps): update github.com/Azure/go-ntlmssp to v0.1.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,22 @@ These are:
     `crane ls --omit-digest-tags registry.k8s.io/sig-storage/csi-node-driver-registrar | sort -V | tail -1`
     - update `nodedriverregistrar_image_tag` in `make/00_mod.mk`
 
+### Pre-release Checks
+
+1. **Check for known vulnerabilities** using `govulncheck` and `trivy`:
+    ```sh
+    # Check the govulncheck GitHub Action is green on main:
+    # https://github.com/cert-manager/csi-driver-spiffe/actions/workflows/govulncheck.yaml
+
+    # Run trivy locally (ArtifactHub uses trivy and flags MEDIUM+ vulnerabilities):
+    make _bin/tools/trivy
+    _bin/tools/trivy fs --scanners vuln .
+    ```
+    If trivy reports vulnerabilities, bump the affected dependencies before tagging,
+    even if they are indirect. ArtifactHub displays trivy results on the
+    [security report page](https://artifacthub.io/packages/helm/cert-manager/cert-manager-csi-driver-spiffe?modal=security-report),
+    and users rely on a clean report.
+
 ### Doing a Release
 
 The release process for this repo is documented below:
@@ -50,6 +66,61 @@ The release process for this repo is documented below:
 
 5. Publish the release.
 
+### Post-release: Verify the Helm Chart Reaches ArtifactHub
+
+The release workflow pushes the Helm chart to `quay.io/jetstack`, and a CI job in
+the private [jetstack/jetstack-charts](https://github.com/jetstack/jetstack-charts)
+repository (accessible only to Palo Alto Networks cert-manager team members) opens
+a PR to sync it to `charts.jetstack.io`. That PR requires a maintainer approval
+before it is merged. Until it is merged, ArtifactHub will continue to show the
+previous version.
+
+```sh
+gh pr list --repo jetstack/jetstack-charts --search "oci-sync" --state open
+```
+
+Review and merge the sync PR, then verify the new version appears on ArtifactHub:
+https://artifacthub.io/packages/helm/cert-manager/cert-manager-csi-driver-spiffe
+
+### Post-release: Check the ArtifactHub Security Report
+
+Once the new version appears on ArtifactHub, check its security report for
+vulnerabilities. ArtifactHub runs trivy against every container image referenced
+in the Helm chart — not just the csi-driver-spiffe images we build, but also the
+sidecar images (livenessprobe, csi-node-driver-registrar). Vulnerabilities in
+sidecar images are outside our control but are still displayed on our package page.
+
+The security report is visible in the web UI at:
+
+https://artifacthub.io/packages/helm/cert-manager/cert-manager-csi-driver-spiffe/VERSION?modal=security-report
+
+It can also be fetched programmatically using the [ArtifactHub API]. The package
+ID for csi-driver-spiffe is `ab494d3e-f81c-44b3-9897-50bec3c88c78`:
+
+```sh
+export VERSION=0.14.0
+make _bin/tools/yq
+curl -sL "https://artifacthub.io/api/v1/packages/ab494d3e-f81c-44b3-9897-50bec3c88c78/${VERSION}/security-report" \
+  | _bin/tools/yq -p json -o tsv '
+    ["IMAGE", "SEVERITY", "CVE", "PACKAGE", "INSTALLED", "FIXED"],
+    (
+      to_entries[] |
+      .key as $image |
+      .value.Results[]? |
+      .Vulnerabilities[]? |
+      [$image, .Severity, .VulnerabilityID, .PkgName, .InstalledVersion, .FixedVersion // "n/a"]
+    ) | @tsv
+  ' | column -t -s$'\t'
+```
+
+If the report shows vulnerabilities in our own images, consider a follow-up patch
+release. Vulnerabilities in sidecar images are fixed upstream in the
+[kubernetes-csi/livenessprobe](https://github.com/kubernetes-csi/livenessprobe) and
+[kubernetes-csi/node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar)
+repositories — check their open PRs and recent releases to see whether a fix has
+been merged but not yet released, and update the sidecar image tags in
+`make/00_mod.mk` once new versions are available.
+
 ## Artifacts
 
 This repo will produce the following artifacts each release. For documentation on how those artifacts are produced see the "Process" section.
@@ -57,5 +128,6 @@ This repo will produce the following artifacts each release. For documentation o
 - *Container Images* - Container images for the are published to `quay.io/jetstack`.
 - *Helm chart* - An official Helm chart is maintained within this repo and published to `quay.io/jetstack` and `charts.jetstack.io` on each release.
 
+[ArtifactHub API]: https://artifacthub.io/docs/api/
 [release workflow]: https://github.com/cert-manager/csi-driver-spiffe/actions/workflows/release.yaml
 [releases page]: https://github.com/cert-manager/csi-driver-spiffe/releases

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+	github.com/Azure/go-ntlmssp v0.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
+github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=


### PR DESCRIPTION
## Summary

- Bumps indirect dependency `github.com/Azure/go-ntlmssp` from v0.0.0-20221128193559-754e69321358 to v0.1.1, fixing CVE-2026-32952 (MEDIUM: DoS via malicious NTLM challenge).
- Documents pre-release vulnerability scanning (govulncheck + trivy), post-release ArtifactHub verification, and post-release security report checking in RELEASE.md.

## Why now?

ArtifactHub displays trivy scan results on the [security report page](https://artifacthub.io/packages/helm/cert-manager/cert-manager-csi-driver-spiffe/0.13.0?modal=security-report) and flags MEDIUM+ vulnerabilities. The v0.13.0 security report shows:

| Image | Vulns | Root cause |
|-------|-------|------------|
| `cert-manager-csi-driver-spiffe:v0.13.0` | Clean | |
| `cert-manager-csi-driver-spiffe-approver:v0.13.0` | 1 MEDIUM | CVE-2026-32952 (go-ntlmssp) — **fixed by this PR** |
| `livenessprobe:v2.19.0` | 1 HIGH + 2 MEDIUM | Go stdlib 1.26.3 needs 1.26.4 |
| `csi-node-driver-registrar:v2.17.0` | 1 HIGH + 2 MEDIUM | Go stdlib 1.26.3 needs 1.26.4 |

The sidecar image vulnerabilities (Go stdlib CVEs) are fixed upstream — [kubernetes-csi/livenessprobe#424](https://github.com/kubernetes-csi/livenessprobe/pull/424) and [kubernetes-csi/node-driver-registrar#587](https://github.com/kubernetes-csi/node-driver-registrar/pull/587) were both merged on 9 June — but no new releases have been cut yet. Those will be resolved when sig-storage publishes new image versions.

## Why didn't Renovate catch this?

Renovate is configured with `osvVulnerabilityAlerts: true` and `:enableVulnerabilityAlerts` (in cert-manager/renovate-config default.json5), and the "Cloud Go deps" package rule matches `github.com/Azure/**`. Despite this, the [Dependency Dashboard](https://github.com/cert-manager/csi-driver-spiffe/issues/411) does not list `go-ntlmssp` at all. Two likely contributing factors:

1. **Indirect dependency**: `go-ntlmssp` is an indirect dependency (`// indirect` in go.mod). Renovate's gomod manager primarily tracks direct dependencies — indirect deps are updated transitively via `go mod tidy` when a direct dependency pulls in a newer version, rather than being independently bumped.
2. **Pseudo-version to tagged release**: The dependency was pinned to a pseudo-version (`v0.0.0-20221128193559-754e69321358`). The fix is a proper semver tag (`v0.1.1`). This transition is awkward for Renovate's version detection, since pseudo-versions don't follow normal semver comparison.

It is unclear whether `osvVulnerabilityAlerts` is expected to cover indirect Go dependencies. This may warrant a follow-up investigation in cert-manager/renovate-config.

## Test plan

- `_bin/tools/go build ./...` — builds cleanly
- `_bin/tools/go test ./...` — all unit tests pass
- `_bin/tools/trivy fs --scanners vuln .` — reports 0 vulnerabilities (previously 1 MEDIUM)
- govulncheck GitHub Action is green on main