### PR TITLE
feat(chart): expose automountServiceAccountToken in the csi-driver-spiffe chart

### DIFF
--- a/deploy/charts/csi-driver-spiffe/README.md
+++ b/deploy/charts/csi-driver-spiffe/README.md
@@ -587,6 +587,14 @@ resources:
 > ```
 
 Optional priority class to be used for the csi-driver pods.
+#### **automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automounting API credentials for the csi-driver-spiffe pods.
+
 #### **commonLabels** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "cert-manager-csi-driver-spiffe.name" . }}
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       containers:
 
         - name: node-driver-registrar

--- a/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
+++ b/deploy/charts/csi-driver-spiffe/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         seccompProfile: { type: RuntimeDefault }
 
       serviceAccountName: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       containers:
       - name: {{ include "cert-manager-csi-driver-spiffe.name" . }}-approver
         {{- $approverImageConfig := include "approver-image-config" . | fromJson }}

--- a/deploy/charts/csi-driver-spiffe/values.schema.json
+++ b/deploy/charts/csi-driver-spiffe/values.schema.json
@@ -12,6 +12,9 @@
         "approverImage": {
           "$ref": "#/$defs/helm-values.approverImage"
         },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.automountServiceAccountToken"
+        },
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
@@ -571,6 +574,11 @@
     "helm-values.approverImage.tag": {
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
       "type": "string"
+    },
+    "helm-values.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automounting API credentials for the csi-driver-spiffe pods.",
+      "type": "boolean"
     },
     "helm-values.commonLabels": {
       "default": {},

--- a/deploy/charts/csi-driver-spiffe/values.yaml
+++ b/deploy/charts/csi-driver-spiffe/values.yaml
@@ -353,6 +353,10 @@ app:
 # Optional priority class to be used for the csi-driver pods.
 priorityClassName: ""
 
+# Automounting API credentials for the csi-driver-spiffe pods.
+# +docs:property
+automountServiceAccountToken: true
+
 # Labels to apply to all resources
 commonLabels: {}
 


### PR DESCRIPTION
## What
Adds an `automountServiceAccountToken` value to the csi-driver-spiffe chart so operators can disable automatic mounting of the ServiceAccount token — a common security-hardening request, matching the option already in the trust-manager chart.

## Details
- New top-level `automountServiceAccountToken` value (defaults to `true`, preserving current behaviour), applied to **both** pod specs (the node `DaemonSet` and the approver `Deployment`), consistent with how `priorityClassName` is handled.
- Regenerated `values.schema.json` and `README.md` with `helm-tool`.

`helm lint` passes; `helm template --set automountServiceAccountToken=false` renders the field on both workloads.