### PR TITLE
chore: let Renovate manage the sidecar image tags in make/00_mod.mk

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,16 +4,20 @@
     'github>cert-manager/makefile-modules:renovate-config.json5',
   ],
   customManagers: [
-    // Update the sidecar image tags in make/00_mod.mk, matching the three-line pattern:
-    //   <x>_image_name_source := <registry>/<image>
-    //   <x>_image_name := <mirror>
-    //   <x>_image_tag := <version>
+    // Update the sidecar image tags in make/00_mod.mk; one manager per
+    // image, each matching a single `<x>_image_tag := vX.Y.Z` line.
     {
       customType: 'regex',
       managerFilePatterns: ['/(^|/)make/00_mod\\.mk$/'],
-      matchStrings: [
-        '_image_name_source := (?<depName>\\S+)\\n[a-z_]+_image_name := \\S+\\n[a-z_]+_image_tag := (?<currentValue>v[\\d.]+)',
-      ],
+      matchStrings: ['livenessprobe_image_tag := (?<currentValue>v[\\d.]+)'],
+      depNameTemplate: 'registry.k8s.io/sig-storage/livenessprobe',
+      datasourceTemplate: 'docker',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/(^|/)make/00_mod\\.mk$/'],
+      matchStrings: ['nodedriverregistrar_image_tag := (?<currentValue>v[\\d.]+)'],
+      depNameTemplate: 'registry.k8s.io/sig-storage/csi-node-driver-registrar',
       datasourceTemplate: 'docker',
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,4 +3,18 @@
   extends: [
     'github>cert-manager/makefile-modules:renovate-config.json5',
   ],
+  customManagers: [
+    // Update the sidecar image tags in make/00_mod.mk, matching the three-line pattern:
+    //   <x>_image_name_source := <registry>/<image>
+    //   <x>_image_name := <mirror>
+    //   <x>_image_tag := <version>
+    {
+      customType: 'regex',
+      managerFilePatterns: ['make/00_mod.mk'],
+      matchStrings: [
+        '_image_name_source := (?<depName>\\S+)\\n[a-z_]+_image_name := \\S+\\n[a-z_]+_image_tag := (?<currentValue>v[\\d.]+)',
+      ],
+      datasourceTemplate: 'docker',
+    },
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,7 @@
     //   <x>_image_tag := <version>
     {
       customType: 'regex',
-      managerFilePatterns: ['make/00_mod.mk'],
+      managerFilePatterns: ['/(^|/)make/00_mod\\.mk$/'],
       matchStrings: [
         '_image_name_source := (?<depName>\\S+)\\n[a-z_]+_image_name := \\S+\\n[a-z_]+_image_tag := (?<currentValue>v[\\d.]+)',
       ],

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -49,6 +49,8 @@ helm_labels_template_name := cert-manager-csi-driver-spiffe.labels
 
 golangci_lint_config := .golangci.yaml
 
+# The image tags below are kept up to date by Renovate
+# (see the customManagers in .github/renovate.json5).
 livenessprobe_image_name_source := registry.k8s.io/sig-storage/livenessprobe
 livenessprobe_image_name := quay.io/jetstack/livenessprobe
 livenessprobe_image_tag := v2.19.0


### PR DESCRIPTION
Adds a Renovate regex custom manager so that the `livenessprobe` and `csi-node-driver-registrar` tags in `make/00_mod.mk` are updated by Renovate (docker datasource against `registry.k8s.io/sig-storage/*`), instead of the manual pre-release step in RELEASE.md.

Same change as cert-manager/csi-driver#715. The regex was validated against the current file, capturing both images (currently already at the latest versions in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)