### PR TITLE
fix(driver): return an error instead of panicking on a non-PEM issued chain

### DIFF
--- a/internal/csi/driver/driver_test.go
+++ b/internal/csi/driver/driver_test.go
@@ -91,6 +91,33 @@ func Test_writeKeyPair(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// writeKeypair computes the next issuance time before writing anything, so a
+// chain it cannot parse must surface as an error and leave the volume empty.
+func Test_writeKeypair_nonPEMChain(t *testing.T) {
+	leafpk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	store := storage.NewMemoryFS()
+	d := &Driver{
+		certFileName: "crt.pem",
+		keyFileName:  "key.pem",
+		store:        store,
+	}
+
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	_, err = store.RegisterMetadata(meta)
+	require.NoError(t, err)
+
+	err = d.writeKeypair(meta, leafpk, []byte("not a PEM encoded certificate"), nil)
+	require.Error(t, err)
+
+	files, err := store.ReadFiles("vol-id")
+	require.NoError(t, err)
+	require.NotContains(t, files, "crt.pem")
+	require.NotContains(t, files, "key.pem")
+}
+
 func Test_DriverAnnotationSanitization(t *testing.T) {
 	badAnnotation := annotations.Prefix + "/customannotation"
 

--- a/internal/csi/driver/util.go
+++ b/internal/csi/driver/util.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"time"
 
@@ -79,6 +80,9 @@ func signRequest(_ metadata.Metadata, key crypto.PrivateKey, request *x509.Certi
 // renewed. This will be 2/3rds the duration of the leaf certificate's validity period.
 func calculateNextIssuanceTime(chain []byte) (time.Time, error) {
 	block, _ := pem.Decode(chain)
+	if block == nil {
+		return time.Time{}, errors.New("parsing issued certificate: no PEM data found in the issued chain")
+	}
 
 	crt, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {

--- a/internal/csi/driver/util_test.go
+++ b/internal/csi/driver/util_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_calculateNextIssuanceTime(t *testing.T) {
+	notBefore := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := time.Date(1970, time.January, 4, 0, 0, 0, 0, time.UTC)
+
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &pk.PublicKey, pk)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	tests := map[string]struct {
+		chain   []byte
+		expTime time.Time
+		expErr  bool
+	}{
+		"a valid chain renews 2/3rds through the leaf's lifetime": {
+			chain:   certPEM,
+			expTime: notBefore.AddDate(0, 0, 2),
+		},
+		"a nil chain is rejected": {
+			chain:  nil,
+			expErr: true,
+		},
+		"an empty chain is rejected": {
+			chain:  []byte{},
+			expErr: true,
+		},
+		"a chain that is not PEM is rejected": {
+			chain:  []byte("this is not a PEM encoded certificate"),
+			expErr: true,
+		},
+		"a truncated PEM block is rejected": {
+			chain:  certPEM[:len(certPEM)/2],
+			expErr: true,
+		},
+		"a PEM block whose contents are not DER is rejected": {
+			chain:  pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not DER")}),
+			expErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			renewTime, err := calculateNextIssuanceTime(test.chain)
+			assert.Equal(t, test.expErr, err != nil)
+			assert.Equal(t, test.expTime, renewTime)
+		})
+	}
+}


### PR DESCRIPTION
Picked up from the open follow-ups in cert-manager/cert-manager#9155:

> Latent nil-pointer panic in `calculateNextIssuanceTime`: the `pem.Decode` result is used without a nil check, so a corrupt stored certificate panics the driver. Fix together with the csi-lib original.

The csi-lib half is cert-manager/csi-lib#288.

## The bug

`pem.Decode` returns a **nil** block when the input contains no PEM data, and the result was dereferenced immediately:

```go
block, _ := pem.Decode(chain)
crt, err := x509.ParseCertificate(block.Bytes)   // panics when block == nil
```

`chain` reaches `writeKeypair` as `req.Status.Certificate` — written by the signer, not by the driver. An issuer that marks a `CertificateRequest` `Ready=True` while putting something other than PEM in `status.certificate` takes down the driver pod on that node rather than failing the one volume.

What makes this worth fixing rather than tolerating is that the caller already states the opposite intent:

```go
// Calculate the next issuance time before we write any data to file, so in
// the cases where this errors, we are not left in a bad state.
nextIssuanceTime, err := calculateNextIssuanceTime(chain)
```

That guarantee only holds while the function can return an error. A panic skips the error path, the `writeKeypair` caller, and the process.

## The fix

Return an error when there is no PEM block, worded like the `x509.ParseCertificate` failure directly below it. No behaviour change for any input that already parsed.

## Verification

- **Revert-checked**: with `util.go` restored to `main` and the tests kept, the run ends in `panic: runtime error: invalid memory address or nil pointer dereference`. With the fix everything passes.
- `Test_calculateNextIssuanceTime` (new — the function had no direct coverage) covers nil, empty, non-PEM, a truncated PEM block, and a PEM block whose contents are not DER, plus the ordinary 2/3rds-of-lifetime case. The not-DER case goes through the pre-existing `ParseCertificate` error path, so it also shows the new branch is not masking errors that were already handled.
- `Test_writeKeypair_nonPEMChain` (new) exercises the comment above end to end: `writeKeypair` returns an error and neither `crt.pem` nor `key.pem` is written to the volume.
- `go test ./...` failure set is **identical** to a pristine tree on this machine (`internal/approver/controller/test` and `test/e2e` need a cluster and fail on `main` too). `gofmt` and `go vet` clean.

---

*Written with assistance from Claude (Opus 5); the analysis, tests and verification above were run and checked by me.*
